### PR TITLE
Add basic workflow engine with runner and actions

### DIFF
--- a/sample_flow.json
+++ b/sample_flow.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.0",
+  "meta": {"name": "demo", "desc": "Sample flow", "permissions": ["desktop.uia"]},
+  "inputs": {"n": 3},
+  "variables": {},
+  "defaults": {"timeoutMs": 1000, "retry": 0, "envProfile": "default"},
+  "steps": [
+    {"id": "s1", "action": "log", "params": {"message": "start"}},
+    {"id": "s2", "action": "set", "params": {"name": "total", "value": 0}},
+    {
+      "id": "s3",
+      "action": "for_each",
+      "for_each": "i",
+      "params": {"items": "range(vars['n'])"},
+      "steps": [
+        {"id": "s3_log", "action": "log", "params": {"message": "loop"}},
+        {"id": "s3_add", "action": "set", "params": {"name": "total", "value": "vars['total'] + i"}}
+      ]
+    },
+    {"id": "s4", "action": "if", "condition": "vars['total'] > 2", "steps": [
+        {"id": "s4_true", "action": "log", "params": {"message": "total>2"}}
+    ], "else": [
+        {"id": "s4_false", "action": "log", "params": {"message": "total<=2"}}
+    ]},
+    {"id": "s5", "action": "log", "params": {"message": "done"}}
+  ]
+}

--- a/workflow/__init__.py
+++ b/workflow/__init__.py
@@ -1,0 +1,6 @@
+"""Workflow engine core package."""
+
+from .flow import Flow, Step
+from .runner import Runner
+
+__all__ = ["Flow", "Step", "Runner"]

--- a/workflow/actions.py
+++ b/workflow/actions.py
@@ -1,0 +1,43 @@
+"""Built-in placeholder actions for the workflow runner."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from .flow import Step
+from .runner import ExecutionContext
+
+
+def log(step: Step, ctx: ExecutionContext) -> Any:
+    """Simple logging action."""
+    message = step.params.get("message", "")
+    print(message)
+    return message
+
+
+def set_var(step: Step, ctx: ExecutionContext) -> Any:
+    """Assign a value to a variable in the requested scope."""
+    name = step.params["name"]
+    value_expr = step.params.get("value")
+    scope = step.params.get("scope", "flow")
+    value = value_expr
+    if isinstance(value_expr, str):
+        env = ctx.all_vars()
+        value = eval(value_expr, {"__builtins__": {}}, {"vars": env, **env})
+    ctx.set_var(name, value, scope=scope)
+    return value
+
+
+def wait(step: Step, ctx: ExecutionContext) -> Any:
+    """Pause execution for the specified milliseconds."""
+    ms = step.params.get("ms", 1000)
+    time.sleep(ms / 1000.0)
+    return ms
+
+
+BUILTIN_ACTIONS = {
+    "log": log,
+    "set": set_var,
+    "wait": wait,
+}

--- a/workflow/flow.py
+++ b/workflow/flow.py
@@ -1,0 +1,109 @@
+"""Data models for workflow definition."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class Meta:
+    """Metadata for a flow."""
+
+    name: str
+    desc: str = ""
+    permissions: List[str] = field(default_factory=list)
+
+
+@dataclass
+class Defaults:
+    """Default settings for all steps."""
+
+    timeoutMs: int = 3000
+    retry: int = 0
+    envProfile: str = "default"
+
+
+@dataclass
+class Step:
+    """Definition of a single step in the flow.
+
+    The model covers both action steps and control-structure steps.
+    """
+
+    id: str
+    action: Optional[str] = None
+    selector: Optional[Dict[str, Any]] = None
+    target: Optional[Dict[str, Any]] = None
+    params: Dict[str, Any] = field(default_factory=dict)
+    waitFor: Optional[str] = None
+    retry: Optional[int] = None
+    onError: Dict[str, Any] = field(default_factory=dict)
+    out: Optional[str] = None
+
+    # ----- control structure fields -----
+    condition: Optional[str] = None
+    while_condition: Optional[str] = None
+    for_each: Optional[str] = None
+    subflow: Optional[str] = None
+    steps: List["Step"] = field(default_factory=list)
+    else_steps: List["Step"] = field(default_factory=list)
+    catch_steps: List["Step"] = field(default_factory=list)
+    finally_steps: List["Step"] = field(default_factory=list)
+
+    break_flag: bool = False
+    continue_flag: bool = False
+
+
+@dataclass
+class Flow:
+    """Top level workflow model."""
+
+    version: str
+    meta: Meta
+    inputs: Dict[str, Any] = field(default_factory=dict)
+    variables: Dict[str, Any] = field(default_factory=dict)
+    defaults: Defaults = field(default_factory=Defaults)
+    steps: List[Step] = field(default_factory=list)
+
+    @staticmethod
+    def _load_steps(data: List[Dict[str, Any]]) -> List[Step]:
+        steps: List[Step] = []
+        for sd in data or []:
+            step = Step(
+                id=sd.get("id", ""),
+                action=sd.get("action"),
+                selector=sd.get("selector"),
+                target=sd.get("target"),
+                params=sd.get("params", {}),
+                waitFor=sd.get("waitFor"),
+                retry=sd.get("retry"),
+                onError=sd.get("onError", {}),
+                out=sd.get("out"),
+                condition=sd.get("condition"),
+                while_condition=sd.get("while"),
+                for_each=sd.get("for_each"),
+                subflow=sd.get("subflow"),
+                break_flag=sd.get("break", False),
+                continue_flag=sd.get("continue", False),
+            )
+            step.steps = Flow._load_steps(sd.get("steps", []))
+            step.else_steps = Flow._load_steps(sd.get("else", []))
+            step.catch_steps = Flow._load_steps(sd.get("catch", []))
+            step.finally_steps = Flow._load_steps(sd.get("finally", []))
+            steps.append(step)
+        return steps
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Flow":
+        meta = Meta(**data.get("meta", {}))
+        defaults = Defaults(**data.get("defaults", {}))
+        steps = cls._load_steps(data.get("steps", []))
+        return cls(
+            version=data.get("version", "1.0"),
+            meta=meta,
+            inputs=data.get("inputs", {}),
+            variables=data.get("variables", {}),
+            defaults=defaults,
+            steps=steps,
+        )

--- a/workflow/runner.py
+++ b/workflow/runner.py
@@ -1,0 +1,198 @@
+"""Interpreter for workflow definitions."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+from .flow import Flow, Step
+
+
+class BreakFlow(Exception):
+    pass
+
+
+class ContinueFlow(Exception):
+    pass
+
+
+@dataclass
+class ExecutionContext:
+    flow: Flow
+    inputs: Dict[str, Any]
+    globals: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.flow_vars = dict(self.flow.inputs)
+        self.flow_vars.update(self.flow.variables)
+        self.flow_vars.update(self.inputs)
+        self.locals_stack: List[Dict[str, Any]] = []
+
+    # ----- variable helpers -----
+    def push_local(self, initial: Optional[Dict[str, Any]] = None) -> None:
+        self.locals_stack.append(initial or {})
+
+    def pop_local(self) -> None:
+        self.locals_stack.pop()
+
+    def set_var(self, name: str, value: Any, scope: str = "local") -> None:
+        if scope == "global":
+            self.globals[name] = value
+        elif scope == "flow":
+            self.flow_vars[name] = value
+        else:
+            if not self.locals_stack:
+                self.locals_stack.append({})
+            self.locals_stack[-1][name] = value
+
+    def get_var(self, name: str) -> Any:
+        for scope in reversed(self.locals_stack):
+            if name in scope:
+                return scope[name]
+        if name in self.flow_vars:
+            return self.flow_vars[name]
+        if name in self.globals:
+            return self.globals[name]
+        raise KeyError(name)
+
+    def all_vars(self) -> Dict[str, Any]:
+        merged = dict(self.globals)
+        merged.update(self.flow_vars)
+        for scope in self.locals_stack:
+            merged.update(scope)
+        return merged
+
+
+ActionFunc = Callable[[Step, ExecutionContext], Any]
+
+
+class Runner:
+    """Execute a :class:`Flow` step by step."""
+
+    def __init__(self) -> None:
+        self.actions: Dict[str, ActionFunc] = {}
+        self.paused = False
+        self.stopped = False
+
+    # ----- registration -----
+    def register_action(self, name: str, func: ActionFunc) -> None:
+        self.actions[name] = func
+
+    # ----- public API -----
+    def run_file(self, path: str, inputs: Optional[Dict[str, Any]] = None) -> None:
+        data = json.loads(Path(path).read_text())
+        flow = Flow.from_dict(data)
+        self.run_flow(flow, inputs or {})
+
+    def run_flow(self, flow: Flow, inputs: Optional[Dict[str, Any]] = None) -> None:
+        ctx = ExecutionContext(flow, inputs or {})
+        self._run_steps(flow.steps, ctx)
+
+    # ----- core execution -----
+    def _run_steps(self, steps: List[Step], ctx: ExecutionContext) -> None:
+        for step in steps:
+            if self.stopped:
+                break
+            while self.paused:
+                time.sleep(0.1)
+            try:
+                self._run_step(step, ctx)
+            except BreakFlow:
+                break
+            except ContinueFlow:
+                continue
+
+    def _eval_expr(self, expr: str, ctx: ExecutionContext) -> Any:
+        env = {"vars": ctx.all_vars(), "range": range}
+        return eval(expr, {"__builtins__": {}}, env)
+
+    def _run_step(self, step: Step, ctx: ExecutionContext) -> None:
+        if step.break_flag:
+            raise BreakFlow()
+        if step.continue_flag:
+            raise ContinueFlow()
+
+        if step.action == "if":
+            cond = self._eval_expr(step.condition or "False", ctx)
+            branch = step.steps if cond else step.else_steps
+            self._run_steps(branch, ctx)
+            print(json.dumps({"stepId": step.id, "action": "if", "result": bool(cond)}))
+            return
+
+        if step.action == "while":
+            while self._eval_expr(step.while_condition or "False", ctx):
+                try:
+                    self._run_steps(step.steps, ctx)
+                except BreakFlow:
+                    break
+                except ContinueFlow:
+                    continue
+            print(json.dumps({"stepId": step.id, "action": "while", "result": "done"}))
+            return
+
+        if step.action == "for_each":
+            iterable = self._eval_expr(step.params.get("items", "[]"), ctx)
+            var_name = step.for_each or "item"
+            for item in iterable:
+                ctx.push_local({var_name: item})
+                try:
+                    self._run_steps(step.steps, ctx)
+                finally:
+                    ctx.pop_local()
+            print(json.dumps({"stepId": step.id, "action": "for_each", "count": len(iterable)}))
+            return
+
+        if step.action == "try":
+            try:
+                self._run_steps(step.steps, ctx)
+            except Exception as exc:
+                ctx.push_local({"error": exc})
+                self._run_steps(step.catch_steps, ctx)
+                ctx.pop_local()
+            finally:
+                self._run_steps(step.finally_steps, ctx)
+            print(json.dumps({"stepId": step.id, "action": "try", "result": "done"}))
+            return
+
+        if step.action == "subflow":
+            path = step.subflow
+            if not path:
+                return
+            data = json.loads(Path(path).read_text())
+            sub = Flow.from_dict(data)
+            self._run_steps(sub.steps, ExecutionContext(sub, ctx.flow_vars))
+            print(json.dumps({"stepId": step.id, "action": "subflow", "result": path}))
+            return
+
+        # actual action
+        func = self.actions.get(step.action)
+        if not func:
+            print(json.dumps({"stepId": step.id, "action": step.action, "result": "unknown"}))
+            return
+        ctx.push_local()
+        log = {"stepId": step.id, "action": step.action}
+        try:
+            result = func(step, ctx)
+            if step.out:
+                ctx.set_var(step.out, result, scope="flow")
+            log["result"] = "ok"
+        except Exception as exc:
+            log["result"] = "error"
+            log["error"] = str(exc)
+            raise
+        finally:
+            print(json.dumps(log))
+            ctx.pop_local()
+
+    # ----- control -----
+    def pause(self) -> None:
+        self.paused = True
+
+    def resume(self) -> None:
+        self.paused = False
+
+    def stop(self) -> None:
+        self.stopped = True


### PR DESCRIPTION
## Summary
- introduce dataclass-based workflow models and interpreter
- implement runner with control constructs, variable scopes, and logging
- add placeholder actions and example flow file

## Testing
- `python -m py_compile workflow/*.py`
- `python - <<'PY'
from workflow.runner import Runner
from workflow.actions import BUILTIN_ACTIONS

r = Runner()
for n,f in BUILTIN_ACTIONS.items():
    r.register_action(n,f)

r.run_file('sample_flow.json')
PY`


------
https://chatgpt.com/codex/tasks/task_e_6896193c1f7083278992ba6dd8347085