### PR TITLE
Use safe expression evaluator in workflow engine

### DIFF
--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,0 +1,23 @@
+import pathlib
+import sys
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from workflow.evaluator import safe_eval
+
+
+def test_arithmetic_and_variables():
+    assert safe_eval("1 + 2 * 3", {}) == 7
+    assert safe_eval("a - b", {"a": 5, "b": 2}) == 3
+
+
+def test_comparisons_and_boolean():
+    vars = {"x": 10, "y": 5}
+    assert safe_eval("x > y", vars) is True
+    assert safe_eval("x < y or x == 10", vars) is True
+
+
+def test_disallows_bad_nodes():
+    with pytest.raises(Exception):
+        safe_eval("__import__('os')", {})

--- a/tests/test_runner_actions.py
+++ b/tests/test_runner_actions.py
@@ -1,0 +1,38 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from workflow import actions
+from workflow.flow import Flow, Meta, Step
+from workflow.runner import ExecutionContext, Runner
+
+
+def build_flow(steps):
+    return Flow(version="1", meta=Meta(name="t"), steps=steps)
+
+
+def test_set_var_expression():
+    flow = build_flow([])
+    ctx = ExecutionContext(flow, {})
+    ctx.set_var("a", 2, scope="flow")
+    step = Step(id="1", params={"name": "b", "value": "a + 3"})
+    result = actions.set_var(step, ctx)
+    assert result == 5
+    assert ctx.get_var("b") == 5
+
+
+def test_runner_eval_expr():
+    steps = [
+        Step(id="1", action="set", params={"name": "x", "value": "1 + 1"}),
+        Step(id="2", action="if", condition="x == 2", steps=[
+            Step(id="3", action="set", params={"name": "y", "value": "x * 3"})
+        ])
+    ]
+    flow = build_flow(steps)
+    runner = Runner()
+    runner.register_action("set", actions.set_var)
+    ctx = ExecutionContext(flow, {})
+    runner._run_steps(flow.steps, ctx)
+    assert ctx.get_var("x") == 2
+    assert ctx.get_var("y") == 6

--- a/workflow/actions.py
+++ b/workflow/actions.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from .flow import Step
 from .runner import ExecutionContext
+from .evaluator import safe_eval
 
 
 def log(step: Step, ctx: ExecutionContext) -> Any:
@@ -23,8 +24,7 @@ def set_var(step: Step, ctx: ExecutionContext) -> Any:
     scope = step.params.get("scope", "flow")
     value = value_expr
     if isinstance(value_expr, str):
-        env = ctx.all_vars()
-        value = eval(value_expr, {"__builtins__": {}}, {"vars": env, **env})
+        value = safe_eval(value_expr, ctx.all_vars())
     ctx.set_var(name, value, scope=scope)
     return value
 

--- a/workflow/evaluator.py
+++ b/workflow/evaluator.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import ast
+import operator as op
+from typing import Any, Dict
+
+# Mapping of supported binary operators to their functions
+_BIN_OPS = {
+    ast.Add: op.add,
+    ast.Sub: op.sub,
+    ast.Mult: op.mul,
+    ast.Div: op.truediv,
+    ast.FloorDiv: op.floordiv,
+    ast.Mod: op.mod,
+    ast.Pow: op.pow,
+}
+
+_UNARY_OPS = {
+    ast.UAdd: op.pos,
+    ast.USub: op.neg,
+}
+
+_CMP_OPS = {
+    ast.Eq: op.eq,
+    ast.NotEq: op.ne,
+    ast.Lt: op.lt,
+    ast.LtE: op.le,
+    ast.Gt: op.gt,
+    ast.GtE: op.ge,
+}
+
+
+def safe_eval(expr: str, variables: Dict[str, Any]) -> Any:
+    """Safely evaluate an arithmetic expression with variables.
+
+    Only arithmetic operations, comparisons and variable references are allowed.
+    """
+    tree = ast.parse(expr, mode="eval")
+    return _eval(tree.body, variables)
+
+
+def _eval(node: ast.AST, variables: Dict[str, Any]) -> Any:
+    if isinstance(node, ast.BinOp):
+        op_type = type(node.op)
+        if op_type not in _BIN_OPS:
+            raise ValueError("Unsupported operator")
+        left = _eval(node.left, variables)
+        right = _eval(node.right, variables)
+        return _BIN_OPS[op_type](left, right)
+    if isinstance(node, ast.UnaryOp):
+        op_type = type(node.op)
+        if op_type not in _UNARY_OPS:
+            raise ValueError("Unsupported unary operator")
+        operand = _eval(node.operand, variables)
+        return _UNARY_OPS[op_type](operand)
+    if isinstance(node, ast.Compare):
+        left = _eval(node.left, variables)
+        for op_node, comparator in zip(node.ops, node.comparators):
+            op_type = type(op_node)
+            if op_type not in _CMP_OPS:
+                raise ValueError("Unsupported comparison operator")
+            right = _eval(comparator, variables)
+            if not _CMP_OPS[op_type](left, right):
+                return False
+            left = right
+        return True
+    if isinstance(node, ast.BoolOp):
+        if isinstance(node.op, ast.And):
+            return all(_eval(v, variables) for v in node.values)
+        if isinstance(node.op, ast.Or):
+            return any(_eval(v, variables) for v in node.values)
+        raise ValueError("Unsupported boolean operator")
+    if isinstance(node, ast.Name):
+        if node.id in variables:
+            return variables[node.id]
+        raise NameError(node.id)
+    if isinstance(node, ast.Constant):
+        if isinstance(node.value, (int, float, bool)):
+            return node.value
+        raise ValueError("Constants of type %s are not allowed" % type(node.value).__name__)
+    raise ValueError(f"Unsupported expression: {ast.dump(node)}")

--- a/workflow/runner.py
+++ b/workflow/runner.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 from .flow import Flow, Step
+from .evaluator import safe_eval
 
 
 class BreakFlow(Exception):
@@ -106,8 +107,7 @@ class Runner:
                 continue
 
     def _eval_expr(self, expr: str, ctx: ExecutionContext) -> Any:
-        env = {"vars": ctx.all_vars(), "range": range}
-        return eval(expr, {"__builtins__": {}}, env)
+        return safe_eval(expr, ctx.all_vars())
 
     def _run_step(self, step: Step, ctx: ExecutionContext) -> None:
         if step.break_flag:


### PR DESCRIPTION
## Summary
- Add `safe_eval` utility to evaluate arithmetic expressions and variable references securely
- Replace Python `eval` usage in `set` action and runner with the new safe evaluator
- Add unit tests covering evaluator, action, and runner expression handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689623b8bbd08327b0d0e4163c1fbae3