### PR TITLE
Add prompt confirm action

### DIFF
--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,0 +1,20 @@
+import builtins
+from workflow.flow import Flow, Meta, Step
+from workflow.runner import ExecutionContext
+from workflow.actions import prompt_input, prompt_confirm
+
+
+def test_prompt_input_returns_default(monkeypatch):
+    step = Step(id="p1", action="prompt.input", params={"message": "Enter", "default": "x"})
+    flow = Flow(version="1", meta=Meta(name="test"))
+    ctx = ExecutionContext(flow, {})
+    monkeypatch.setattr(builtins, "input", lambda prompt="": "")
+    assert prompt_input(step, ctx) == "x"
+
+
+def test_prompt_confirm_returns_default(monkeypatch):
+    step = Step(id="c1", action="prompt.confirm", params={"message": "Proceed?", "default": True})
+    flow = Flow(version="1", meta=Meta(name="test"))
+    ctx = ExecutionContext(flow, {})
+    monkeypatch.setattr(builtins, "input", lambda prompt="": "")
+    assert prompt_confirm(step, ctx) is True

--- a/workflow/actions.py
+++ b/workflow/actions.py
@@ -37,6 +37,57 @@ def wait(step: Step, ctx: ExecutionContext) -> Any:
     return ms
 
 
+def prompt_input(step: Step, ctx: ExecutionContext) -> Any:
+    """Prompt the user for input during execution.
+
+    Parameters
+    ----------
+    message: str
+        Message shown to the user.
+    default: Any, optional
+        Default value if the user provides empty input.
+    """
+    message = step.params.get("message", "")
+    default = step.params.get("default")
+    prompt = f"{message} " if message else ""
+    if default is not None:
+        prompt += f"[{default}] "
+    value = input(prompt)
+    if value == "" and default is not None:
+        value = default
+    return value
+
+
+def prompt_confirm(step: Step, ctx: ExecutionContext) -> bool:
+    """Prompt the user for a yes/no confirmation.
+
+    Parameters
+    ----------
+    message: str
+        Message shown to the user.
+    default: bool, optional
+        Value returned when the user provides empty input.
+    """
+    message = step.params.get("message", "")
+    default = step.params.get("default")
+    prompt = f"{message} " if message else ""
+    if default is None:
+        prompt += "[y/n] "
+    elif default:
+        prompt += "[Y/n] "
+    else:
+        prompt += "[y/N] "
+    while True:
+        ans = input(prompt).strip().lower()
+        if ans == "" and default is not None:
+            return bool(default)
+        if ans in ("y", "yes"):
+            return True
+        if ans in ("n", "no"):
+            return False
+        print("Please enter y or n")
+
+
 def _stub_action(step: Step, ctx: ExecutionContext) -> Any:
     """Placeholder for unimplemented UI actions."""
     print(f"{step.action} not implemented")
@@ -47,6 +98,8 @@ BUILTIN_ACTIONS = {
     "log": log,
     "set": set_var,
     "wait": wait,
+    "prompt.input": prompt_input,
+    "prompt.confirm": prompt_confirm,
 }
 
 _UI_ACTIONS = [


### PR DESCRIPTION
## Summary
- implement `prompt.confirm` action to capture yes/no input with optional default
- cover `prompt.confirm` with unit test

## Testing
- `python -m pytest -q`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6896bcde6c548327b43d831078bd2fc1