### PR TITLE
Add switch control structure to workflow runner

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,37 @@
+from workflow.flow import Flow
+from workflow.runner import ExecutionContext, Runner
+from workflow.actions import BUILTIN_ACTIONS
+
+
+def run_flow_with_x(x):
+    data = {
+        "version": "1",
+        "meta": {"name": "t"},
+        "steps": [
+            {"id": "set", "action": "set", "params": {"name": "x", "value": x}},
+            {
+                "id": "sw",
+                "action": "switch",
+                "switch": "vars['x']",
+                "cases": [
+                    {"value": 1, "steps": [{"id": "case1", "action": "set", "params": {"name": "res", "value": 1}}]},
+                    {"value": 2, "steps": [{"id": "case2", "action": "set", "params": {"name": "res", "value": 2}}]},
+                ],
+                "default": [
+                    {"id": "default", "action": "set", "params": {"name": "res", "value": 0}}
+                ],
+            },
+        ],
+    }
+    flow = Flow.from_dict(data)
+    ctx = ExecutionContext(flow, {})
+    runner = Runner()
+    for name, func in BUILTIN_ACTIONS.items():
+        runner.register_action(name, func)
+    runner._run_steps(flow.steps, ctx)
+    return ctx.get_var("res")
+
+
+def test_switch_cases_and_default():
+    assert run_flow_with_x(2) == 2
+    assert run_flow_with_x(3) == 0

--- a/workflow/flow.py
+++ b/workflow/flow.py
@@ -47,10 +47,13 @@ class Step:
     while_condition: Optional[str] = None
     for_each: Optional[str] = None
     subflow: Optional[str] = None
+    switch_expr: Optional[str] = None
     steps: List["Step"] = field(default_factory=list)
     else_steps: List["Step"] = field(default_factory=list)
     catch_steps: List["Step"] = field(default_factory=list)
     finally_steps: List["Step"] = field(default_factory=list)
+    cases: List[Dict[str, Any]] = field(default_factory=list)
+    default_steps: List["Step"] = field(default_factory=list)
 
     break_flag: bool = False
     continue_flag: bool = False
@@ -86,6 +89,7 @@ class Flow:
                 while_condition=sd.get("while"),
                 for_each=sd.get("for_each"),
                 subflow=sd.get("subflow"),
+                switch_expr=sd.get("switch"),
                 break_flag=sd.get("break", False),
                 continue_flag=sd.get("continue", False),
             )
@@ -93,6 +97,11 @@ class Flow:
             step.else_steps = Flow._load_steps(sd.get("else", []))
             step.catch_steps = Flow._load_steps(sd.get("catch", []))
             step.finally_steps = Flow._load_steps(sd.get("finally", []))
+            step.cases = []
+            for cd in sd.get("cases", []):
+                case_steps = Flow._load_steps(cd.get("steps", []))
+                step.cases.append({"value": cd.get("value"), "steps": case_steps})
+            step.default_steps = Flow._load_steps(sd.get("default", []))
             steps.append(step)
         return steps
 

--- a/workflow/runner.py
+++ b/workflow/runner.py
@@ -136,6 +136,22 @@ class Runner:
             print(json.dumps({"stepId": step.id, "action": "while", "result": "done"}))
             return
 
+        if step.action == "switch":
+            value = self._eval_expr(step.switch_expr or "None", ctx)
+            matched = False
+            for case in step.cases:
+                case_val = case.get("value")
+                if isinstance(case_val, str):
+                    case_val = self._eval_expr(case_val, ctx)
+                if value == case_val:
+                    self._run_steps(case.get("steps", []), ctx)
+                    matched = True
+                    break
+            if not matched:
+                self._run_steps(step.default_steps, ctx)
+            print(json.dumps({"stepId": step.id, "action": "switch", "result": value}))
+            return
+
         if step.action == "for_each":
             iterable = self._eval_expr(step.params.get("items", "[]"), ctx)
             var_name = step.for_each or "item"


### PR DESCRIPTION
## Summary
- extend flow model to describe switch/case steps
- execute switch branches in runner with default handling
- cover switch cases with new unit test and path setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896c0e77b28832784141f2add9dd21e