### PR TITLE
Add logging and artifact capture to workflow runner

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,51 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from workflow.flow import Flow, Meta, Step
+from workflow.runner import Runner
+from workflow.actions import BUILTIN_ACTIONS
+
+
+def build_runner(tmp_path: Path, run_id: str = "run") -> Runner:
+    runner = Runner(run_id=run_id, base_dir=tmp_path)
+    for name, func in BUILTIN_ACTIONS.items():
+        runner.register_action(name, func)
+    return runner
+
+
+def test_log_written(tmp_path):
+    step = Step(id="s", action="set", params={"name": "x", "value": 1})
+    flow = Flow(version="1", meta=Meta(name="t"), steps=[step])
+    runner = build_runner(tmp_path, run_id="abc")
+
+    runner.run_flow(flow, {})
+
+    log_file = runner.run_dir / "log.jsonl"
+    assert log_file.exists()
+    lines = [json.loads(l) for l in log_file.read_text().splitlines()]
+    assert lines[0]["runId"] == "abc"
+    assert lines[0]["stepId"] == "s"
+    assert lines[0]["result"] == "ok"
+
+
+def test_failure_artifacts(tmp_path):
+    def fail(step, ctx):
+        raise RuntimeError("boom")
+
+    step = Step(id="f", action="fail")
+    flow = Flow(version="1", meta=Meta(name="t"), steps=[step])
+    runner = build_runner(tmp_path, run_id="err")
+    runner.register_action("fail", fail)
+
+    with pytest.raises(RuntimeError):
+        runner.run_flow(flow, {})
+
+    log_file = runner.run_dir / "log.jsonl"
+    lines = [json.loads(l) for l in log_file.read_text().splitlines()]
+    record = lines[0]
+    assert record["result"] == "error"
+    shot = Path(record["screenshot"])
+    tree = Path(record["uiTree"])
+    assert shot.exists() and tree.exists()

--- a/workflow/logging.py
+++ b/workflow/logging.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def log_step(
+    run_id: str,
+    run_dir: Path,
+    step_id: str,
+    action: str,
+    duration: float,
+    result: str,
+    **extra: Any,
+) -> None:
+    """Append a step execution record to the run log.
+
+    Parameters
+    ----------
+    run_id: str
+        Identifier for the current run.
+    run_dir: Path
+        Directory for run-specific logs and artifacts.
+    step_id: str
+        ID of the executed step.
+    action: str
+        Name of the action performed.
+    duration: float
+        Duration of the step in milliseconds.
+    result: str
+        Result of the step (e.g. ``"ok"`` or ``"error"``).
+    extra: dict
+        Additional fields to include in the log record.
+    """
+
+    record: Dict[str, Any] = {
+        "runId": run_id,
+        "stepId": step_id,
+        "action": action,
+        "duration": duration,
+        "result": result,
+    }
+    record.update(extra)
+    log_path = run_dir / "log.jsonl"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record) + "\n")


### PR DESCRIPTION
## Summary
- Add `log_step` utility to write structured JSON step logs per run
- Record step execution in `Runner` with run-specific directories and failure artifact capture
- Test logging behavior and artifact creation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896c5cdbd48832799bdc1684884da19