### PR TITLE
Implement Playwright web actions

### DIFF
--- a/tests/test_actions_web.py
+++ b/tests/test_actions_web.py
@@ -1,0 +1,48 @@
+import pytest
+
+pytest.importorskip("playwright.sync_api")
+
+from workflow.flow import Flow, Meta, Step
+from workflow.runner import ExecutionContext
+from workflow.actions_web import (
+    open as web_open,
+    click as web_click,
+    fill as web_fill,
+    wait_for as web_wait_for,
+    download as web_download,
+)
+
+
+def build_ctx():
+    flow = Flow(version="1", meta=Meta(name="test"), steps=[])
+    return ExecutionContext(flow, {})
+
+
+def test_playwright_actions(tmp_path):
+    html = (
+        "<html><body>"
+        "<input id='name'>"
+        "<button id='btn' onclick=\"document.getElementById('result').textContent=document.getElementById('name').value\">Go</button>"
+        "<div id='result'></div>"
+        "<a id='dl' href='data:text/plain,hello' download='hello.txt'>Download</a>"
+        "</body></html>"
+    )
+    page_file = tmp_path / "index.html"
+    page_file.write_text(html)
+    ctx = build_ctx()
+
+    web_open(Step(id="open", action="open", params={"url": page_file.as_uri()}), ctx)
+    web_fill(Step(id="fill", action="fill", params={"selector": "#name", "value": "Alice"}), ctx)
+    page = ctx.globals["_page"]
+    assert page.input_value("#name") == "Alice"
+
+    web_click(Step(id="click", action="click", params={"selector": "#btn"}), ctx)
+    web_wait_for(Step(id="wait", action="wait_for", params={"selector": "#result:has-text(\"Alice\")"}), ctx)
+    assert page.inner_text("#result") == "Alice"
+
+    dl_path = tmp_path / "hello.txt"
+    web_download(Step(id="dl", action="download", params={"selector": "#dl", "path": str(dl_path)}), ctx)
+    assert dl_path.exists()
+
+    ctx.globals["_browser"].close()
+    ctx.globals["_playwright"].stop()

--- a/workflow/actions.py
+++ b/workflow/actions.py
@@ -92,3 +92,7 @@ _UI_ACTIONS = [
 
 for _name in _UI_ACTIONS:
     BUILTIN_ACTIONS[_name] = _stub_action
+
+from .actions_web import WEB_ACTIONS
+
+BUILTIN_ACTIONS.update(WEB_ACTIONS)

--- a/workflow/actions_web.py
+++ b/workflow/actions_web.py
@@ -1,0 +1,89 @@
+"""Web automation actions implemented using Playwright."""
+from __future__ import annotations
+
+from typing import Any
+
+try:  # pragma: no cover - optional dependency
+    from playwright.sync_api import Page, sync_playwright
+except Exception:  # pragma: no cover - optional dependency
+    Page = Any  # type: ignore
+    sync_playwright = None
+
+from .flow import Step
+from .runner import ExecutionContext
+
+_PW_KEY = "_playwright"
+_BROWSER_KEY = "_browser"
+_PAGE_KEY = "_page"
+
+
+def _get_page(ctx: ExecutionContext) -> Page:
+    if sync_playwright is None:
+        raise RuntimeError("Playwright is not installed")
+    page = ctx.globals.get(_PAGE_KEY)
+    if page:
+        return page
+    pw = ctx.globals.get(_PW_KEY)
+    if pw is None:
+        pw = sync_playwright().start()
+        ctx.globals[_PW_KEY] = pw
+    browser = ctx.globals.get(_BROWSER_KEY)
+    if browser is None:
+        browser = pw.chromium.launch()
+        ctx.globals[_BROWSER_KEY] = browser
+    page = browser.new_page()
+    ctx.globals[_PAGE_KEY] = page
+    return page
+
+
+def open(step: Step, ctx: ExecutionContext) -> Any:
+    url = step.params["url"]
+    page = _get_page(ctx)
+    page.goto(url)
+    return url
+
+
+def click(step: Step, ctx: ExecutionContext) -> Any:
+    selector = step.params["selector"]
+    page = _get_page(ctx)
+    page.click(selector)
+    return selector
+
+
+def fill(step: Step, ctx: ExecutionContext) -> Any:
+    selector = step.params["selector"]
+    value = step.params.get("value", "")
+    page = _get_page(ctx)
+    page.fill(selector, value)
+    return value
+
+
+def wait_for(step: Step, ctx: ExecutionContext) -> Any:
+    selector = step.params["selector"]
+    timeout = step.params.get("timeout", 10000)
+    page = _get_page(ctx)
+    page.wait_for_selector(selector, timeout=timeout)
+    return selector
+
+
+def download(step: Step, ctx: ExecutionContext) -> Any:
+    selector = step.params["selector"]
+    path = step.params.get("path")
+    page = _get_page(ctx)
+    with page.expect_download() as dl_info:
+        page.click(selector)
+    download = dl_info.value
+    if path:
+        download.save_as(path)
+        return path
+    tmp = download.path()
+    return str(tmp)
+
+
+WEB_ACTIONS = {
+    "open": open,
+    "click": click,
+    "fill": fill,
+    "wait_for": wait_for,
+    "download": download,
+}


### PR DESCRIPTION
## Summary
- add Playwright-based web actions (open, click, fill, wait_for, download)
- register web actions with builtin registry
- cover web actions with tests leveraging Playwright

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6896c6d88dd88327871b2ff26668bb14