### PR TITLE
Add Excel automation actions

### DIFF
--- a/tests/test_actions_office.py
+++ b/tests/test_actions_office.py
@@ -1,0 +1,37 @@
+from unittest.mock import MagicMock
+
+from workflow.flow import Flow, Meta, Step
+from workflow.runner import ExecutionContext
+import workflow.actions_office as office
+
+
+def build_ctx():
+    flow = Flow(version="1", meta=Meta(name="test"), steps=[])
+    return ExecutionContext(flow, {})
+
+
+def test_excel_actions(monkeypatch):
+    app = MagicMock()
+    wb = MagicMock()
+    sheet = MagicMock()
+    rng = MagicMock()
+    rng.Value = "old"
+    sheet.Range.return_value = rng
+    wb.ActiveSheet = sheet
+    app.Workbooks.Open.return_value = wb
+
+    monkeypatch.setattr(office, "win32", MagicMock(Dispatch=lambda prog_id: app))
+
+    ctx = build_ctx()
+
+    office.excel_open(Step(id="open", action="excel.open", params={"path": "file.xlsx"}), ctx)
+    assert ctx.globals["_excel_book"] is wb
+
+    office.excel_set(Step(id="set", action="excel.set", params={"cell": "A1", "value": 123}), ctx)
+    assert rng.Value == 123
+
+    value = office.excel_get(Step(id="get", action="excel.get", params={"cell": "A1"}), ctx)
+    assert value == 123
+
+    office.excel_save(Step(id="save", action="excel.save", params={}), ctx)
+    wb.Save.assert_called_once()

--- a/workflow/actions.py
+++ b/workflow/actions.py
@@ -94,5 +94,7 @@ for _name in _UI_ACTIONS:
     BUILTIN_ACTIONS[_name] = _stub_action
 
 from .actions_web import WEB_ACTIONS
+from .actions_office import OFFICE_ACTIONS
 
 BUILTIN_ACTIONS.update(WEB_ACTIONS)
+BUILTIN_ACTIONS.update(OFFICE_ACTIONS)

--- a/workflow/actions_office.py
+++ b/workflow/actions_office.py
@@ -1,0 +1,73 @@
+"""Office automation actions using win32com."""
+from __future__ import annotations
+
+from typing import Any
+
+try:  # pragma: no cover - optional dependency
+    import win32com.client as win32
+except Exception:  # pragma: no cover - optional dependency
+    win32 = None  # type: ignore
+
+from .flow import Step
+from .runner import ExecutionContext
+
+# keys for storing excel app and workbook in execution context
+_EXCEL_APP = "_excel_app"
+_EXCEL_BOOK = "_excel_book"
+
+
+def excel_open(step: Step, ctx: ExecutionContext) -> Any:
+    """Open an Excel workbook."""
+    if win32 is None:
+        raise RuntimeError("win32com.client is not installed")
+    path = step.params["path"]
+    visible = step.params.get("visible", False)
+    app = ctx.globals.get(_EXCEL_APP)
+    if app is None:
+        app = win32.Dispatch("Excel.Application")
+        ctx.globals[_EXCEL_APP] = app
+    app.Visible = visible
+    wb = app.Workbooks.Open(path)
+    ctx.globals[_EXCEL_BOOK] = wb
+    return path
+
+
+def excel_get(step: Step, ctx: ExecutionContext) -> Any:
+    """Get value from a cell."""
+    cell = step.params["cell"]
+    sheet_name = step.params.get("sheet")
+    wb = ctx.globals[_EXCEL_BOOK]
+    sheet = wb.Worksheets(sheet_name) if sheet_name else wb.ActiveSheet
+    rng = sheet.Range(cell)
+    return rng.Value
+
+
+def excel_set(step: Step, ctx: ExecutionContext) -> Any:
+    """Set value of a cell."""
+    cell = step.params["cell"]
+    value = step.params.get("value")
+    sheet_name = step.params.get("sheet")
+    wb = ctx.globals[_EXCEL_BOOK]
+    sheet = wb.Worksheets(sheet_name) if sheet_name else wb.ActiveSheet
+    rng = sheet.Range(cell)
+    rng.Value = value
+    return value
+
+
+def excel_save(step: Step, ctx: ExecutionContext) -> Any:
+    """Save the workbook."""
+    wb = ctx.globals[_EXCEL_BOOK]
+    path = step.params.get("path")
+    if path:
+        wb.SaveAs(path)
+        return path
+    wb.Save()
+    return True
+
+
+OFFICE_ACTIONS = {
+    "excel.open": excel_open,
+    "excel.get": excel_get,
+    "excel.set": excel_set,
+    "excel.save": excel_save,
+}


### PR DESCRIPTION
## Summary
- implement Excel automation helpers using win32com (open, get, set, save)
- register Excel helpers in builtin actions
- cover Excel helpers with unit tests using mocked COM objects

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896c7f9fcb08327ab5d0a549d1efdbf