### PR TITLE
Add confirmation and selection prompt actions

### DIFF
--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,7 +1,7 @@
 import builtins
 from workflow.flow import Flow, Meta, Step
 from workflow.runner import ExecutionContext
-from workflow.actions import prompt_input
+from workflow.actions import prompt_input, prompt_confirm, prompt_select
 
 
 def test_prompt_input_returns_default(monkeypatch):
@@ -10,3 +10,23 @@ def test_prompt_input_returns_default(monkeypatch):
     ctx = ExecutionContext(flow, {})
     monkeypatch.setattr(builtins, "input", lambda prompt="": "")
     assert prompt_input(step, ctx) == "x"
+
+
+def test_prompt_confirm_default(monkeypatch):
+    step = Step(id="c1", action="prompt.confirm", params={"message": "Continue?", "default": True})
+    flow = Flow(version="1", meta=Meta(name="test"))
+    ctx = ExecutionContext(flow, {})
+    monkeypatch.setattr(builtins, "input", lambda prompt="": "")
+    assert prompt_confirm(step, ctx) is True
+
+
+def test_prompt_select_by_index(monkeypatch):
+    step = Step(
+        id="s1",
+        action="prompt.select",
+        params={"message": "Pick", "options": ["a", "b", "c"]},
+    )
+    flow = Flow(version="1", meta=Meta(name="test"))
+    ctx = ExecutionContext(flow, {})
+    monkeypatch.setattr(builtins, "input", lambda prompt="": "2")
+    assert prompt_select(step, ctx) == "b"


### PR DESCRIPTION
## Summary
- support yes/no confirmation via `prompt.confirm`
- allow choosing from a list of options via `prompt.select`
- test default confirmation behavior and selection by index

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896c93b82c08327827bd685083347c3