### PR TITLE
Add selector resolver with strategy fallback

### DIFF
--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -1,0 +1,19 @@
+import pytest
+
+from workflow.actions import BUILTIN_ACTIONS
+from workflow.flow import Step, Flow, Meta
+from workflow.runner import ExecutionContext
+
+
+def make_context():
+    flow = Flow(version="1.0", meta=Meta(name="t"))
+    return ExecutionContext(flow, {})
+
+
+def test_fallback_to_image_selector():
+    """When UIA fails, the resolver should use the image selector."""
+    step = Step(id="s1", action="launch", selector={"uia": {"exists": False}, "image": {"path": "btn.png"}})
+    ctx = make_context()
+    result = BUILTIN_ACTIONS["launch"](step, ctx)
+    assert result["strategy"] == "image"
+    assert ctx.globals["learned_selectors"] == ["image"]

--- a/workflow/actions.py
+++ b/workflow/actions.py
@@ -8,6 +8,7 @@ from typing import Any
 from .flow import Step
 from .runner import ExecutionContext
 from .safe_eval import safe_eval
+from .selector import resolve as resolve_selector
 
 
 def log(step: Step, ctx: ExecutionContext) -> Any:
@@ -154,7 +155,20 @@ def prompt_select(step: Step, ctx: ExecutionContext) -> Any:
 
 
 def _stub_action(step: Step, ctx: ExecutionContext) -> Any:
-    """Placeholder for unimplemented UI actions."""
+    """Placeholder for unimplemented UI actions.
+
+    The stub uses :func:`resolve_selector` to attempt element resolution based on
+    the step's ``selector`` definition.  Successful resolutions are recorded on
+    the execution context under ``ctx.globals['learned_selectors']`` so tests can
+    verify which strategy was ultimately used.
+    """
+
+    selector = step.selector or step.params.get("selector")
+    if isinstance(selector, dict):
+        result = resolve_selector(selector)
+        strategies = ctx.globals.setdefault("learned_selectors", [])
+        strategies.append(result["strategy"])
+        return result
     print(f"{step.action} not implemented")
     return None
 

--- a/workflow/selector.py
+++ b/workflow/selector.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+"""Simple selector resolver with multiple strategies."""
+
+from typing import Any, Dict, Tuple
+
+
+class SelectionError(Exception):
+    """Raised when a selector cannot be resolved."""
+
+
+def _resolve_uia(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Resolve UIA based selectors.
+
+    The implementation is intentionally lightweight for testing.  When the
+    supplied data contains ``{"exists": False}`` a :class:`SelectionError`
+    is raised to simulate a failed lookup; otherwise the data is returned.
+    """
+
+    if data.get("exists", True):
+        return data
+    raise SelectionError("UIA element not found")
+
+
+def _resolve_win32(data: Dict[str, Any]) -> Dict[str, Any]:
+    return data
+
+
+def _resolve_anchor(data: Dict[str, Any]) -> Dict[str, Any]:
+    return data
+
+
+def _resolve_image(data: Dict[str, Any]) -> Dict[str, Any]:
+    return data
+
+
+def _resolve_coordinate(data: Dict[str, Any]) -> Dict[str, Any]:
+    return data
+
+
+_STRATEGIES = {
+    "uia": _resolve_uia,
+    "win32": _resolve_win32,
+    "anchor": _resolve_anchor,
+    "image": _resolve_image,
+    "coordinate": _resolve_coordinate,
+}
+
+
+def resolve(selector: Dict[str, Any]) -> Dict[str, Any]:
+    """Resolve a selector using the available strategies.
+
+    Parameters
+    ----------
+    selector:
+        Mapping containing zero or more strategy entries such as ``"uia"`` or
+        ``"image"``.  Strategies are attempted in the order UIA, Win32, anchor,
+        image and finally coordinate.  The first successful resolution is
+        returned in the form ``{"strategy": name, "target": data}``.
+
+    Raises
+    ------
+    SelectionError
+        If none of the strategies succeed.
+    """
+
+    for name in ["uia", "win32", "anchor", "image", "coordinate"]:
+        data = selector.get(name)
+        if not data:
+            continue
+        resolver = _STRATEGIES[name]
+        try:
+            resolved = resolver(data)
+        except SelectionError:
+            continue
+        return {"strategy": name, "target": resolved}
+    raise SelectionError("No selector strategy could resolve the element")


### PR DESCRIPTION
## Summary
- Introduce a selector resolver handling UIA, Win32, anchor, image, and coordinate strategies
- Record successful selector strategies during UI actions for future learning
- Test fallback from UIA to image selectors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896d7c348bc83278f55689c945da289