### PR TITLE
feat: enhance web actions with frame and download support

### DIFF
--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -3,6 +3,7 @@ import pytest
 from workflow.actions import BUILTIN_ACTIONS
 from workflow.flow import Step, Flow, Meta
 from workflow.runner import ExecutionContext
+from workflow.selector import normalize_selector, suggest_selector
 
 
 def make_context():
@@ -17,3 +18,8 @@ def test_fallback_to_image_selector():
     result = BUILTIN_ACTIONS["attach"](step, ctx)
     assert result["strategy"] == "image"
     assert ctx.globals["learned_selectors"] == ["image"]
+
+
+def test_selector_normalization_and_suggestion():
+    assert normalize_selector("#save") == ["[data-testid=\"save\"]", "#save"]
+    assert suggest_selector("button#save") == "[data-testid=\"save\"]"

--- a/workflow/actions_web.py
+++ b/workflow/actions_web.py
@@ -1,6 +1,7 @@
 """Web automation actions implemented using Playwright."""
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 try:  # pragma: no cover - optional dependency
@@ -11,6 +12,7 @@ except Exception:  # pragma: no cover - optional dependency
 
 from .flow import Step
 from .runner import ExecutionContext
+from .selector import normalize_selector
 
 _PW_KEY = "_playwright"
 _BROWSER_KEY = "_browser"
@@ -45,39 +47,77 @@ def open(step: Step, ctx: ExecutionContext) -> Any:
 
 def click(step: Step, ctx: ExecutionContext) -> Any:
     selector = step.params["selector"]
+    frame = step.params.get("frame")
     page = _get_page(ctx)
-    page.click(selector)
+    target = page.frame_locator(frame) if frame else page
+    for sel in normalize_selector(selector):
+        loc = target.locator(sel)
+        if loc.count():
+            loc.click()
+            return sel
+    # Fall back to original selector
+    target.locator(selector).click()
     return selector
 
 
 def fill(step: Step, ctx: ExecutionContext) -> Any:
     selector = step.params["selector"]
     value = step.params.get("value", "")
+    frame = step.params.get("frame")
     page = _get_page(ctx)
-    page.fill(selector, value)
+    target = page.frame_locator(frame) if frame else page
+    for sel in normalize_selector(selector):
+        loc = target.locator(sel)
+        if loc.count():
+            loc.fill(value)
+            return value
+    target.locator(selector).fill(value)
     return value
 
 
 def wait_for(step: Step, ctx: ExecutionContext) -> Any:
     selector = step.params["selector"]
     timeout = step.params.get("timeout", 10000)
+    frame = step.params.get("frame")
     page = _get_page(ctx)
-    page.wait_for_selector(selector, timeout=timeout)
+    target = page.frame_locator(frame) if frame else page
+    for sel in normalize_selector(selector):
+        loc = target.locator(sel)
+        try:
+            loc.wait_for(timeout=timeout)
+            return sel
+        except Exception:
+            continue
+    target.locator(selector).wait_for(timeout=timeout)
     return selector
 
 
 def download(step: Step, ctx: ExecutionContext) -> Any:
     selector = step.params["selector"]
     path = step.params.get("path")
+    frame = step.params.get("frame")
     page = _get_page(ctx)
+    target = page.frame_locator(frame) if frame else page
+    # Locate element prioritizing data-testid
+    for sel in normalize_selector(selector):
+        loc = target.locator(sel)
+        if loc.count():
+            chosen = loc
+            break
+    else:
+        chosen = target.locator(selector)
+
     with page.expect_download() as dl_info:
-        page.click(selector)
+        chosen.click()
     download = dl_info.value
     if path:
         download.save_as(path)
-        return path
-    tmp = download.path()
-    return str(tmp)
+        saved = Path(path)
+    else:
+        saved = Path(download.path())
+    if not saved.exists() or saved.stat().st_size == 0:
+        raise RuntimeError("Download failed")
+    return str(saved)
 
 
 WEB_ACTIONS = {

--- a/workflow/selector.py
+++ b/workflow/selector.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Simple selector resolver with multiple strategies."""
 
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Tuple, List
 
 
 class SelectionError(Exception):
@@ -75,3 +75,30 @@ def resolve(selector: Dict[str, Any]) -> Dict[str, Any]:
             continue
         return {"strategy": name, "target": resolved}
     raise SelectionError("No selector strategy could resolve the element")
+
+
+def _extract_token(selector: str) -> str:
+    """Extract a token suitable for ``data-testid`` from a selector."""
+
+    for sep in ["#", ".", " "]:
+        if sep in selector:
+            selector = selector.split(sep)[-1]
+    return selector
+
+
+def normalize_selector(selector: str) -> List[str]:
+    """Return candidate selectors prioritising ``data-testid``.
+
+    The returned list always contains a selector targeting ``data-testid``
+    followed by the original selector as a fallback.
+    """
+
+    token = _extract_token(selector)
+    return [f'[data-testid="{token}"]', selector]
+
+
+def suggest_selector(selector: str) -> str:
+    """Suggest a ``data-testid`` based selector for the given input."""
+
+    token = _extract_token(selector)
+    return f'[data-testid="{token}"]'


### PR DESCRIPTION
## Summary
- add selector normalization and suggestion utilities
- scope web actions to specific frames with data-testid prioritization
- verify downloads by checking saved file exists and is non-empty

## Testing
- `pytest tests/test_selector.py tests/test_actions_web.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6896db1e1410832789a9451d3383c2b0