### PR TITLE
Add Word and Outlook automation actions with tests

### DIFF
--- a/tests/test_actions_outlook.py
+++ b/tests/test_actions_outlook.py
@@ -1,0 +1,31 @@
+from unittest.mock import MagicMock
+
+from workflow.flow import Flow, Meta, Step
+from workflow.runner import ExecutionContext
+import workflow.actions_outlook as outlook
+
+
+def build_ctx():
+    flow = Flow(version="1", meta=Meta(name="test"), steps=[])
+    return ExecutionContext(flow, {})
+
+
+def test_outlook_actions(monkeypatch):
+    app = MagicMock()
+    item = MagicMock()
+    session = MagicMock()
+    session.OpenSharedItem.return_value = item
+    app.Session = session
+    app.Application.Run = MagicMock()
+    monkeypatch.setattr(outlook, "win32", MagicMock(Dispatch=lambda prog_id: app))
+
+    ctx = build_ctx()
+
+    outlook.outlook_open(Step(id="open", action="outlook.open", params={"path": "mail.msg"}), ctx)
+    assert ctx.globals["_outlook_item"] is item
+
+    outlook.outlook_save(Step(id="save", action="outlook.save", params={"path": "saved.msg"}), ctx)
+    item.SaveAs.assert_called_once_with("saved.msg")
+
+    outlook.outlook_run_macro(Step(id="macro", action="outlook.run_macro", params={"name": "Macro1"}), ctx)
+    app.Application.Run.assert_called_once_with("Macro1")

--- a/tests/test_actions_word.py
+++ b/tests/test_actions_word.py
@@ -1,0 +1,28 @@
+from unittest.mock import MagicMock
+
+from workflow.flow import Flow, Meta, Step
+from workflow.runner import ExecutionContext
+import workflow.actions_word as word
+
+
+def build_ctx():
+    flow = Flow(version="1", meta=Meta(name="test"), steps=[])
+    return ExecutionContext(flow, {})
+
+
+def test_word_actions(monkeypatch):
+    app = MagicMock()
+    doc = MagicMock()
+    app.Documents.Open.return_value = doc
+    monkeypatch.setattr(word, "win32", MagicMock(Dispatch=lambda prog_id: app))
+
+    ctx = build_ctx()
+
+    word.word_open(Step(id="open", action="word.open", params={"path": "file.docx"}), ctx)
+    assert ctx.globals["_word_doc"] is doc
+
+    word.word_save(Step(id="save", action="word.save", params={}), ctx)
+    doc.Save.assert_called_once()
+
+    word.word_run_macro(Step(id="macro", action="word.run_macro", params={"name": "Macro1"}), ctx)
+    app.Run.assert_called_once_with("Macro1")

--- a/workflow/actions.py
+++ b/workflow/actions.py
@@ -396,6 +396,10 @@ BUILTIN_ACTIONS.update(
 
 from .actions_web import WEB_ACTIONS
 from .actions_office import OFFICE_ACTIONS
+from .actions_word import WORD_ACTIONS
+from .actions_outlook import OUTLOOK_ACTIONS
 
 BUILTIN_ACTIONS.update(WEB_ACTIONS)
 BUILTIN_ACTIONS.update(OFFICE_ACTIONS)
+BUILTIN_ACTIONS.update(WORD_ACTIONS)
+BUILTIN_ACTIONS.update(OUTLOOK_ACTIONS)

--- a/workflow/actions_outlook.py
+++ b/workflow/actions_outlook.py
@@ -1,0 +1,55 @@
+"""Outlook automation actions using win32com."""
+from __future__ import annotations
+
+from typing import Any
+
+try:  # pragma: no cover - optional dependency
+    import win32com.client as win32
+except Exception:  # pragma: no cover - optional dependency
+    win32 = None  # type: ignore
+
+from .flow import Step
+from .runner import ExecutionContext
+
+# keys for storing outlook app and item in execution context
+_OUTLOOK_APP = "_outlook_app"
+_OUTLOOK_ITEM = "_outlook_item"
+
+
+def outlook_open(step: Step, ctx: ExecutionContext) -> Any:
+    """Open an Outlook item from a file."""
+    if win32 is None:
+        raise RuntimeError("win32com.client is not installed")
+    path = step.params["path"]
+    app = ctx.globals.get(_OUTLOOK_APP)
+    if app is None:
+        app = win32.Dispatch("Outlook.Application")
+        ctx.globals[_OUTLOOK_APP] = app
+    item = app.Session.OpenSharedItem(path)
+    ctx.globals[_OUTLOOK_ITEM] = item
+    return path
+
+
+def outlook_save(step: Step, ctx: ExecutionContext) -> Any:
+    """Save the currently opened Outlook item."""
+    item = ctx.globals[_OUTLOOK_ITEM]
+    path = step.params.get("path")
+    if path:
+        item.SaveAs(path)
+        return path
+    item.Save()
+    return True
+
+
+def outlook_run_macro(step: Step, ctx: ExecutionContext) -> Any:
+    """Run a macro in the Outlook application."""
+    macro = step.params["name"]
+    app = ctx.globals[_OUTLOOK_APP]
+    return app.Application.Run(macro)
+
+
+OUTLOOK_ACTIONS = {
+    "outlook.open": outlook_open,
+    "outlook.save": outlook_save,
+    "outlook.run_macro": outlook_run_macro,
+}

--- a/workflow/actions_word.py
+++ b/workflow/actions_word.py
@@ -1,0 +1,57 @@
+"""Word automation actions using win32com."""
+from __future__ import annotations
+
+from typing import Any
+
+try:  # pragma: no cover - optional dependency
+    import win32com.client as win32
+except Exception:  # pragma: no cover - optional dependency
+    win32 = None  # type: ignore
+
+from .flow import Step
+from .runner import ExecutionContext
+
+# keys for storing word app and document in execution context
+_WORD_APP = "_word_app"
+_WORD_DOC = "_word_doc"
+
+
+def word_open(step: Step, ctx: ExecutionContext) -> Any:
+    """Open a Word document."""
+    if win32 is None:
+        raise RuntimeError("win32com.client is not installed")
+    path = step.params["path"]
+    visible = step.params.get("visible", False)
+    app = ctx.globals.get(_WORD_APP)
+    if app is None:
+        app = win32.Dispatch("Word.Application")
+        ctx.globals[_WORD_APP] = app
+    app.Visible = visible
+    doc = app.Documents.Open(path)
+    ctx.globals[_WORD_DOC] = doc
+    return path
+
+
+def word_save(step: Step, ctx: ExecutionContext) -> Any:
+    """Save the active Word document."""
+    doc = ctx.globals[_WORD_DOC]
+    path = step.params.get("path")
+    if path:
+        doc.SaveAs(path)
+        return path
+    doc.Save()
+    return True
+
+
+def word_run_macro(step: Step, ctx: ExecutionContext) -> Any:
+    """Run a macro in the Word application."""
+    macro = step.params["name"]
+    app = ctx.globals[_WORD_APP]
+    return app.Run(macro)
+
+
+WORD_ACTIONS = {
+    "word.open": word_open,
+    "word.save": word_save,
+    "word.run_macro": word_run_macro,
+}


### PR DESCRIPTION
## Summary
- implement Word automation module with open, save and macro actions
- implement Outlook automation module with open, save and macro actions
- register Word and Outlook actions in built-in action map
- add tests using win32com mocks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6896dc4636cc832796692c68ad7f0e41