### PR TITLE
Add profile-based runner config and fallback

### DIFF
--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,51 @@
+import time
+
+from workflow.flow import Defaults, Flow, Meta, Step
+from workflow.runner import Runner
+import workflow.config as cfg
+
+
+def _make_action(attempts):
+    def action(step, ctx):
+        attempts.append(ctx.globals.get("profile"))
+        time.sleep(0.15)
+        return "done"
+    return action
+
+
+def test_profile_fallback(monkeypatch):
+    # Shrink timeouts for faster testing
+    monkeypatch.setitem(cfg.PROFILES, "physical", cfg.ProfileConfig(timeoutMs=100, retry=0, fallback=["vdi"]))
+    monkeypatch.setitem(cfg.PROFILES, "vdi", cfg.ProfileConfig(timeoutMs=250, retry=0, fallback=[]))
+
+    attempts = []
+    runner = Runner()
+    runner.register_action("test", _make_action(attempts))
+    flow = Flow(
+        version="1.0",
+        meta=Meta(name="p"),
+        defaults=Defaults(envProfile="physical"),
+        steps=[Step(id="s", action="test", out="r")],
+    )
+    result = runner.run_flow(flow, {})
+    assert result["r"] == "done"
+    assert attempts == ["physical", "vdi"]
+
+
+def test_profile_selection(monkeypatch):
+    # Use only vdi profile, ensure no fallback occurs
+    monkeypatch.setitem(cfg.PROFILES, "physical", cfg.ProfileConfig(timeoutMs=100, retry=0, fallback=[]))
+    monkeypatch.setitem(cfg.PROFILES, "vdi", cfg.ProfileConfig(timeoutMs=250, retry=0, fallback=[]))
+
+    attempts = []
+    runner = Runner()
+    runner.register_action("test", _make_action(attempts))
+    flow = Flow(
+        version="1.0",
+        meta=Meta(name="v"),
+        defaults=Defaults(envProfile="vdi"),
+        steps=[Step(id="s", action="test", out="r")],
+    )
+    result = runner.run_flow(flow, {})
+    assert result["r"] == "done"
+    assert attempts == ["vdi"]

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -9,6 +9,7 @@ def test_resume_from_failed_step(tmp_path):
     flow_dict = {
         "version": "1.0",
         "meta": {"name": "test"},
+        "defaults": {"envProfile": "vdi"},
         "steps": [
             {"id": "s1", "action": "set", "params": {"name": "x", "value": 1}},
             {"id": "s2", "action": "fail_once"},

--- a/workflow/config.py
+++ b/workflow/config.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass(frozen=True)
+class ProfileConfig:
+    """Configuration for a runtime environment profile."""
+
+    timeoutMs: int
+    retry: int
+    fallback: List[str] = field(default_factory=list)
+
+
+DEFAULT_PROFILE = "physical"
+
+# Default profile definitions. These are intentionally small so tests run quickly.
+PROFILES: Dict[str, ProfileConfig] = {
+    "physical": ProfileConfig(timeoutMs=1000, retry=0, fallback=["vdi"]),
+    "vdi": ProfileConfig(timeoutMs=2000, retry=0, fallback=[]),
+}
+
+
+def get_profile_chain(start: str | None) -> List[str]:
+    """Return the list of profiles to try starting with ``start``.
+
+    Fallbacks are resolved recursively while preserving the order declared in
+    :data:`PROFILES`. Unknown profiles default to :data:`DEFAULT_PROFILE`.
+    """
+
+    seen: set[str] = set()
+    order: List[str] = []
+
+    def _add(name: str) -> None:
+        if name in seen:
+            return
+        profile = PROFILES.get(name)
+        if profile is None:
+            return
+        seen.add(name)
+        order.append(name)
+        for fb in profile.fallback:
+            _add(fb)
+
+    start_name = start if start in PROFILES else DEFAULT_PROFILE
+    _add(start_name)
+    return order

--- a/workflow/flow.py
+++ b/workflow/flow.py
@@ -17,11 +17,16 @@ class Meta:
 
 @dataclass
 class Defaults:
-    """Default settings for all steps."""
+    """Default settings for all steps.
 
-    timeoutMs: int = 3000
-    retry: int = 0
-    envProfile: str = "default"
+    ``timeoutMs`` and ``retry`` are optional and, when not provided, fall back
+    to the values defined by the active execution profile (see
+    :mod:`workflow.config`).
+    """
+
+    timeoutMs: Optional[int] = None
+    retry: Optional[int] = None
+    envProfile: str = "physical"
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- add configurable execution profiles for physical and VDI environments
- allow runner to use profile timeouts and fallback order when retrying steps
- test profile selection and fallback behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896dda2a38483278e640f03004bef63