### PR TITLE
Add SQLite run logging and dashboard

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from argparse import ArgumentParser
+from pathlib import Path
+
+from workflow.log_db import init_db, get_success_rate, get_average_duration
+
+
+def main() -> None:
+    parser = ArgumentParser(description='Generate simple HTML dashboard with run metrics.')
+    parser.add_argument('--db', default='runs.sqlite', help='Path to SQLite database file')
+    parser.add_argument('--output', default='dashboard.html', help='Path to output HTML file')
+    args = parser.parse_args()
+
+    conn = init_db(args.db)
+    success_rate = get_success_rate(conn)
+    avg_duration = get_average_duration(conn)
+
+    html = f"""<!DOCTYPE html>
+<html>
+<head><meta charset='utf-8'><title>Run Metrics</title></head>
+<body>
+<h1>Run Metrics</h1>
+<ul>
+<li>Success rate: {success_rate:.2%}</li>
+<li>Average duration: {avg_duration:.2f} seconds</li>
+</ul>
+</body>
+</html>
+"""
+    Path(args.output).write_text(html, encoding='utf-8')
+    print(f'Dashboard written to {args.output}')
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_log_db.py
+++ b/tests/test_log_db.py
@@ -1,0 +1,11 @@
+import pytest
+from workflow.log_db import init_db, log_run, get_success_rate, get_average_duration
+
+
+def test_metrics_computation():
+    conn = init_db(':memory:')
+    log_run(conn, '1', 'flow', 0.0, 1.0, True)
+    log_run(conn, '2', 'flow', 0.0, 2.0, False)
+    log_run(conn, '3', 'flow', 0.0, 3.0, True)
+    assert pytest.approx(get_success_rate(conn)) == 2 / 3
+    assert pytest.approx(get_average_duration(conn)) == 2.0

--- a/workflow/log_db.py
+++ b/workflow/log_db.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Union
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT UNIQUE,
+    flow_name TEXT,
+    start_time REAL,
+    end_time REAL,
+    duration REAL,
+    success INTEGER
+);
+"""
+
+def init_db(db_path: Union[str, Path]) -> sqlite3.Connection:
+    """Initialize the SQLite database and return a connection.
+
+    Parameters
+    ----------
+    db_path: str or Path
+        Location of the SQLite database file. Use ":memory:" for an in-memory DB.
+    """
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(SCHEMA)
+    conn.commit()
+    return conn
+
+def log_run(
+    conn: sqlite3.Connection,
+    run_id: str,
+    flow_name: str,
+    start_time: float,
+    end_time: float,
+    success: bool,
+) -> None:
+    """Record the outcome of a workflow run.
+
+    Parameters
+    ----------
+    conn: sqlite3.Connection
+        Database connection obtained from ``init_db``.
+    run_id: str
+        Identifier for the run.
+    flow_name: str
+        Name of the executed flow.
+    start_time: float
+        Start time in seconds since the epoch.
+    end_time: float
+        End time in seconds since the epoch.
+    success: bool
+        ``True`` if the run completed successfully, ``False`` otherwise.
+    """
+    duration = end_time - start_time
+    conn.execute(
+        "INSERT INTO runs (run_id, flow_name, start_time, end_time, duration, success) VALUES (?, ?, ?, ?, ?, ?)",
+        (run_id, flow_name, start_time, end_time, duration, int(success)),
+    )
+    conn.commit()
+
+def get_success_rate(conn: sqlite3.Connection) -> float:
+    """Return the success rate of logged runs as a fraction between 0 and 1."""
+    cur = conn.execute("SELECT AVG(success) FROM runs")
+    row = cur.fetchone()
+    return row[0] if row and row[0] is not None else 0.0
+
+def get_average_duration(conn: sqlite3.Connection) -> float:
+    """Return the average duration of logged runs in seconds."""
+    cur = conn.execute("SELECT AVG(duration) FROM runs")
+    row = cur.fetchone()
+    return row[0] if row and row[0] is not None else 0.0


### PR DESCRIPTION
## Summary
- Implement SQLite-based run log with analytics for success rate and average duration
- Provide test coverage for logging metrics
- Add dashboard script to render aggregated metrics as HTML

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896df19c3a48327948788f601f9dc17