### PR TITLE
Add secrets management, package signing, and role-based runner checks

### DIFF
--- a/tests/test_package_utils.py
+++ b/tests/test_package_utils.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+from workflow.package_utils import sign_package, verify_package
+
+
+def test_sign_and_verify(tmp_path: Path):
+    pkg = tmp_path / "flow.pkg"
+    pkg.write_text("data")
+    key = b"secret"
+    sign_package(pkg, key)
+    assert verify_package(pkg, key) is True
+    assert verify_package(pkg, b"wrong") is False

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,0 +1,18 @@
+import builtins
+import pytest
+from workflow.flow import Flow, Meta, Step
+from workflow.runner import Runner
+from workflow.actions import BUILTIN_ACTIONS
+
+
+def test_runner_requires_role(monkeypatch):
+    step = Step(id="p", action="prompt.input", params={"message": "", "default": "x"}, out="ans")
+    flow = Flow(version="1", meta=Meta(name="t"), steps=[step])
+    runner = Runner()
+    for name, func in BUILTIN_ACTIONS.items():
+        runner.register_action(name, func)
+    monkeypatch.setattr(builtins, "input", lambda prompt="": "y")
+    with pytest.raises(PermissionError):
+        runner.run_flow(flow, {})
+    result = runner.run_flow(flow, {"roles": ["user"]})
+    assert result["ans"] == "y"

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,0 +1,7 @@
+from workflow import secrets
+
+
+def test_secret_roundtrip():
+    secrets.set_secret("api_key", "123")
+    assert secrets.get_secret("api_key") == "123"
+    assert secrets.get_secret("missing") is None

--- a/workflow/package_utils.py
+++ b/workflow/package_utils.py
@@ -1,0 +1,43 @@
+"""Utilities to sign and verify flow packages."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+import hashlib
+import hmac
+
+PathLike = Union[str, Path]
+
+
+def _sig_path(path: Path) -> Path:
+    return path.with_suffix(path.suffix + ".sig")
+
+
+def sign_package(path: PathLike, key: bytes) -> str:
+    """Create an HMAC-SHA256 signature for ``path`` using ``key``.
+
+    The signature is written alongside the file with the same name plus a
+    ``.sig`` suffix.  The hexadecimal signature string is also returned.
+    """
+    p = Path(path)
+    data = p.read_bytes()
+    signature = hmac.new(key, data, hashlib.sha256).hexdigest()
+    _sig_path(p).write_text(signature)
+    return signature
+
+
+def verify_package(path: PathLike, key: bytes) -> bool:
+    """Verify the signature of ``path`` using ``key``.
+
+    Returns ``True`` when the signature matches, otherwise ``False``.
+    """
+    p = Path(path)
+    sig_file = _sig_path(p)
+    if not sig_file.exists():
+        return False
+    expected = sig_file.read_text().strip()
+    actual = hmac.new(key, p.read_bytes(), hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, actual)
+
+
+__all__ = ["sign_package", "verify_package"]

--- a/workflow/secrets.py
+++ b/workflow/secrets.py
@@ -1,0 +1,55 @@
+"""Utilities for storing and retrieving secrets.
+
+On Windows the credentials are stored using the Windows Credential Manager.
+On other platforms a simple in-memory fallback store is used.  The fallback
+is primarily intended for testing purposes.
+"""
+from __future__ import annotations
+
+from typing import Optional, Dict
+import sys
+
+_fallback_store: Dict[str, str] = {}
+
+if sys.platform == "win32":  # pragma: no cover - Windows specific
+    try:
+        import win32cred  # type: ignore
+    except Exception:  # pragma: no cover - if pywin32 is missing
+        win32cred = None
+else:  # pragma: no cover - executed on non-Windows
+    win32cred = None  # type: ignore
+
+
+def set_secret(name: str, value: str) -> None:
+    """Store ``value`` under ``name``.
+
+    On Windows this writes to the Credential Manager.  On other platforms the
+    value is kept in a process-local dictionary.
+    """
+    if win32cred:  # pragma: no cover - only executed on Windows
+        credential = {
+            "Type": win32cred.CRED_TYPE_GENERIC,
+            "TargetName": name,
+            "CredentialBlob": value.encode("utf-16"),
+            "Persist": win32cred.CRED_PERSIST_LOCAL_MACHINE,
+        }
+        win32cred.CredWrite(credential, 0)
+    else:
+        _fallback_store[name] = value
+
+
+def get_secret(name: str) -> Optional[str]:
+    """Retrieve the secret stored under ``name``.
+
+    Returns ``None`` when the secret does not exist.
+    """
+    if win32cred:  # pragma: no cover - only executed on Windows
+        try:
+            cred = win32cred.CredRead(name, win32cred.CRED_TYPE_GENERIC)
+            return cred["CredentialBlob"].decode("utf-16")
+        except Exception:
+            return None
+    return _fallback_store.get(name)
+
+
+__all__ = ["set_secret", "get_secret"]


### PR DESCRIPTION
## Summary
- Integrate Windows Credential Manager backed secrets utility with in-memory fallback
- Add flow package signing/verification helpers using HMAC-SHA256
- Enforce role-based authorization for sensitive actions in the workflow runner

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896e01c3da883279142b125c58d07d6