### PR TITLE
Implement cron scheduler with crash reporting

### DIFF
--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,51 @@
+import json
+import threading
+import time
+from datetime import datetime
+
+from workflow.scheduler import CronScheduler
+
+
+def test_scheduler_exclusive_access(tmp_path):
+    counter = tmp_path / "count.txt"
+    counter.write_text("0")
+
+    def job():
+        count = int(counter.read_text())
+        time.sleep(0.1)
+        counter.write_text(str(count + 1))
+
+    lock = tmp_path / "job.lock"
+    cron = "* * * * * *"
+    s1 = CronScheduler()
+    s2 = CronScheduler()
+    s1.add_job(cron, job, lock)
+    s2.add_job(cron, job, lock)
+    now = datetime.now().replace(microsecond=0)
+
+    t1 = threading.Thread(target=lambda: s1.run_pending(now))
+    t2 = threading.Thread(target=lambda: s2.run_pending(now))
+    t1.start(); t2.start(); t1.join(); t2.join()
+
+    assert counter.read_text() == "1"
+
+
+def test_crash_report_creation(tmp_path):
+    log_file = tmp_path / "run.log"
+    log_file.write_text("start\n")
+
+    def job():
+        log_file.write_text(log_file.read_text() + "before crash\n")
+        raise RuntimeError("boom")
+
+    reports = tmp_path / "reports"
+    s = CronScheduler()
+    s.add_job("* * * * * *", job, tmp_path / "lock", log_file=log_file, report_dir=reports)
+    s.run_pending(datetime.now())
+
+    files = list(reports.glob("crash_*.json"))
+    assert files
+    data = json.loads(files[0].read_text())
+    assert data["error"] == "boom"
+    assert "python" in data["env"]
+    assert "before crash" in data["log"]

--- a/workflow/__init__.py
+++ b/workflow/__init__.py
@@ -2,5 +2,6 @@
 
 from .flow import Flow, Step
 from .runner import Runner
+from .scheduler import CronScheduler, capture_crash
 
-__all__ = ["Flow", "Step", "Runner"]
+__all__ = ["Flow", "Step", "Runner", "CronScheduler", "capture_crash"]

--- a/workflow/scheduler.py
+++ b/workflow/scheduler.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import platform
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, List, Optional
+
+
+def _match_field(field: str, value: int) -> bool:
+    if field == "*":
+        return True
+    if field.startswith("*/"):
+        step = int(field[2:])
+        return value % step == 0
+    for part in field.split(","):
+        if part and int(part) == value:
+            return True
+    return False
+
+
+def _cron_match(expr: str, dt: datetime) -> bool:
+    fields = expr.split()
+    if len(fields) == 5:
+        fields = ["0"] + fields
+    if len(fields) != 6:
+        raise ValueError("Cron expression must have 5 or 6 fields")
+    second, minute, hour, day, month, weekday = fields
+    checks = [
+        (second, dt.second),
+        (minute, dt.minute),
+        (hour, dt.hour),
+        (day, dt.day),
+        (month, dt.month),
+        (weekday, dt.weekday()),
+    ]
+    return all(_match_field(f, v) for f, v in checks)
+
+
+def capture_crash(exc: Exception, log_file: Optional[Path], report_dir: Path) -> Path:
+    """Write a crash report with log and environment data."""
+    report_dir.mkdir(parents=True, exist_ok=True)
+    log_content = ""
+    if log_file and log_file.exists():
+        log_content = log_file.read_text()
+    data = {
+        "error": str(exc),
+        "env": {
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+        },
+        "log": log_content,
+    }
+    path = report_dir / f"crash_{int(time.time() * 1000)}.json"
+    path.write_text(json.dumps(data))
+    return path
+
+
+@dataclass
+class ScheduledJob:
+    cron: str
+    func: Callable[[], None]
+    lock_file: Path
+    log_file: Optional[Path] = None
+    report_dir: Path = Path("reports")
+
+
+class CronScheduler:
+    """Simple cron-like scheduler with file locking."""
+
+    def __init__(self) -> None:
+        self.jobs: List[ScheduledJob] = []
+
+    def add_job(
+        self,
+        cron: str,
+        func: Callable[[], None],
+        lock_file: Path | str,
+        log_file: Optional[Path | str] = None,
+        report_dir: Path | str = Path("reports"),
+    ) -> None:
+        job = ScheduledJob(
+            cron,
+            func,
+            Path(lock_file),
+            Path(log_file) if log_file else None,
+            Path(report_dir),
+        )
+        self.jobs.append(job)
+
+    def run_pending(self, now: Optional[datetime] = None) -> None:
+        now = now or datetime.now()
+        for job in self.jobs:
+            if not _cron_match(job.cron, now):
+                continue
+            job.lock_file.parent.mkdir(parents=True, exist_ok=True)
+            fd = os.open(job.lock_file, os.O_RDWR | os.O_CREAT)
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                os.close(fd)
+                continue
+            try:
+                job.func()
+            except Exception as exc:  # pragma: no cover - defensive
+                capture_crash(exc, job.log_file, job.report_dir)
+            finally:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+                os.close(fd)


### PR DESCRIPTION
## Summary
- add `CronScheduler` with file-based locking and crash report generation
- expose scheduler utilities in workflow package
- test exclusive access and crash report creation

## Testing
- `pytest tests/test_scheduler.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6896e1868b188327864c134e5e565542