### PR TITLE
Track selector strategy success rates

### DIFF
--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -1,9 +1,10 @@
+import json
 import pytest
 
 from workflow.actions import BUILTIN_ACTIONS
 from workflow.flow import Step, Flow, Meta
 from workflow.runner import ExecutionContext
-from workflow.selector import normalize_selector, suggest_selector
+from workflow.selector import normalize_selector, suggest_selector, resolve, SelectionError
 
 
 def make_context():
@@ -23,3 +24,29 @@ def test_fallback_to_image_selector():
 def test_selector_normalization_and_suggestion():
     assert normalize_selector("#save") == ["[data-testid=\"save\"]", "#save"]
     assert suggest_selector("button#save") == "[data-testid=\"save\"]"
+
+
+def test_strategy_stats_affect_order(tmp_path):
+    """Strategies are tried based on historical success rate."""
+
+    run_dir = tmp_path
+    # First call: UIA fails, image succeeds -> higher success rate for image
+    resolve({"uia": {"exists": False}, "image": {"path": "img.png"}}, run_dir=run_dir)
+
+    # Second call: both succeed but image should be chosen due to stats
+    result = resolve({"uia": {"exists": True}, "image": {"path": "img.png"}}, run_dir=run_dir)
+    assert result["strategy"] == "image"
+
+    stats_file = run_dir / "selector_stats.json"
+    data = json.loads(stats_file.read_text())
+    assert data["uia"]["attempts"] >= 1
+    assert data["image"]["success"] >= 1
+
+
+def test_stats_persist_on_failure(tmp_path):
+    run_dir = tmp_path
+    with pytest.raises(SelectionError):
+        resolve({"uia": {"exists": False}}, run_dir=run_dir)
+    data = json.loads((run_dir / "selector_stats.json").read_text())
+    assert data["uia"]["attempts"] == 1
+    assert data["uia"]["success"] == 0


### PR DESCRIPTION
## Summary
- track attempt and success counts for each selector strategy
- persist strategy hit stats to run-specific JSON files
- order selector resolution by historical success rate

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896e744394483278253988e62f14bfb