### PR TITLE
Add IME utilities and secure desktop handling

### DIFF
--- a/tests/test_ime_layout.py
+++ b/tests/test_ime_layout.py
@@ -1,0 +1,34 @@
+import types
+import sys
+
+from workflow.flow import Flow, Meta, Step
+from workflow.runner import ExecutionContext
+from workflow import actions
+
+
+def build_ctx():
+    flow = Flow(version="1", meta=Meta(name="test"), steps=[])
+    return ExecutionContext(flow, {})
+
+
+def test_ime_toggle(monkeypatch):
+    calls = []
+    pa = types.SimpleNamespace(hotkey=lambda *keys: calls.append(keys))
+    sys.modules["pyautogui"] = pa
+    ctx = build_ctx()
+    actions.ime_on(Step(id="i1", action="ime.on"), ctx)
+    actions.ime_off(Step(id="i2", action="ime.off"), ctx)
+    assert calls == [("ctrl", "space"), ("ctrl", "space")]
+    assert ctx.globals["ime_state"] == "off"
+
+
+def test_layout_switch(monkeypatch):
+    calls = []
+    pa = types.SimpleNamespace(hotkey=lambda *keys: calls.append(keys))
+    sys.modules["pyautogui"] = pa
+    ctx = build_ctx()
+    actions.switch_layout(
+        Step(id="l1", action="layout.switch", params={"layout": "us"}), ctx
+    )
+    assert calls == [("alt", "shift")]
+    assert ctx.globals["keyboard_layout"] == "us"

--- a/tests/test_runner_uac.py
+++ b/tests/test_runner_uac.py
@@ -1,0 +1,36 @@
+from workflow.flow import Flow, Meta, Step
+from workflow.runner import Runner, ExecutionContext
+import workflow.runner as runner_mod
+
+
+def make_ctx():
+    flow = Flow(version="1", meta=Meta(name="t"), steps=[])
+    return ExecutionContext(flow, {})
+
+
+def test_handles_uac_prompt(monkeypatch, capsys):
+    runner = Runner()
+    runner.register_action("noop", lambda step, ctx: None)
+    step = Step(id="s", action="noop")
+    ctx = make_ctx()
+    uac_states = iter([True, False])
+    monkeypatch.setattr(runner, "_has_uac_prompt", lambda: next(uac_states, False))
+    monkeypatch.setattr(runner, "_is_secure_desktop", lambda: False)
+    monkeypatch.setattr(runner_mod.time, "sleep", lambda x: None)
+    runner._run_step(step, ctx)
+    out = capsys.readouterr().out
+    assert "uacPrompt" in out
+
+
+def test_handles_secure_desktop(monkeypatch, capsys):
+    runner = Runner()
+    runner.register_action("noop", lambda step, ctx: None)
+    step = Step(id="s", action="noop")
+    ctx = make_ctx()
+    sd_states = iter([True, False])
+    monkeypatch.setattr(runner, "_is_secure_desktop", lambda: next(sd_states, False))
+    monkeypatch.setattr(runner, "_has_uac_prompt", lambda: False)
+    monkeypatch.setattr(runner_mod.time, "sleep", lambda x: None)
+    runner._run_step(step, ctx)
+    out = capsys.readouterr().out
+    assert "secureDesktop" in out

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -5,6 +5,7 @@ from workflow.actions import BUILTIN_ACTIONS
 from workflow.flow import Step, Flow, Meta
 from workflow.runner import ExecutionContext
 from workflow.selector import normalize_selector, suggest_selector, resolve, SelectionError
+import workflow.selector as sel
 
 
 def make_context():
@@ -50,3 +51,12 @@ def test_stats_persist_on_failure(tmp_path):
     data = json.loads((run_dir / "selector_stats.json").read_text())
     assert data["uia"]["attempts"] == 1
     assert data["uia"]["success"] == 0
+
+
+def test_vdi_fallback(monkeypatch):
+    """Image strategy is prioritised when running in VDI mode."""
+
+    monkeypatch.setenv("VDI_MODE", "1")
+    sel._HIT_STATS = {name: {"attempts": 0, "success": 0} for name in sel._STRATEGIES}
+    result = resolve({"uia": {"exists": True}, "image": {"path": "btn.png"}})
+    assert result["strategy"] == "image"

--- a/workflow/selector.py
+++ b/workflow/selector.py
@@ -116,6 +116,8 @@ def resolve(selector: Dict[str, Any], run_dir: Path | str | None = None) -> Dict
 
     strategies = [name for name in selector if name in _STRATEGIES]
     base_order = ["uia", "win32", "anchor", "image", "coordinate"]
+    if os.getenv("RPA_VDI") or os.getenv("VDI") or os.getenv("VDI_MODE"):
+        base_order = ["image", "coordinate", "uia", "win32", "anchor"]
 
     def rate(name: str) -> float:
         stats = _HIT_STATS.get(name, {"attempts": 0, "success": 0})


### PR DESCRIPTION
## Summary
- add IME on/off and keyboard layout switch helpers
- detect UAC prompts and secure desktop in runner
- prefer image/coordinate selectors when VDI mode is active

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896f2b745908327b7cb6f258db3f32c