### PR TITLE
feat: enhance selector normalization

### DIFF
--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -21,3 +21,11 @@ def test_capture_coordinates_basis_preview(monkeypatch):
 
     res_preview = gui_tools.capture_coordinates(preview=True)
     assert res_preview["preview"] == (100, 200)
+
+
+def test_record_web_suggests_stable_selectors():
+    actions = [{"selector": "button#save"}]
+    result = gui_tools.record_web(actions)
+    suggestions = result[0]["selectorSuggestions"]
+    assert suggestions[0] == "[data-testid=\"save\"]"
+    assert "#save" in suggestions

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -23,7 +23,11 @@ def test_fallback_to_image_selector():
 
 
 def test_selector_normalization_and_suggestion():
-    assert normalize_selector("#save") == ["[data-testid=\"save\"]", "#save"]
+    assert normalize_selector("#save") == [
+        "[data-testid=\"save\"]",
+        "#save",
+        "//*[@id=\"save\"]",
+    ]
     assert suggest_selector("button#save") == "[data-testid=\"save\"]"
 
 

--- a/workflow/gui_tools.py
+++ b/workflow/gui_tools.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, List, Tuple
 
+from .selector import analyze_selectors
+
 try:  # pragma: no cover - optional GUI dependency
     from PyQt6.QtGui import QCursor
 except Exception:  # pragma: no cover - headless environments
@@ -71,12 +73,13 @@ def capture_coordinates(
 def record_web(actions: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Record a sequence of web actions.
 
-    The function merely echoes the actions and serves as an integration point
-    for a future browser recorder.  Returning the list makes it convenient to
-    unit test and to directly wire into flow definitions.
+    Currently the function echoes the supplied actions but augments any
+    selectors with stable attribute suggestions via
+    :func:`selector.analyze_selectors`.  Returning the list makes it convenient
+    to unit test and to directly wire into flow definitions.
     """
 
-    return actions
+    return analyze_selectors(actions)
 
 
 def wire_to_flow(flow: Dict[str, Any], step_id: str, params: Dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary
- expand selector normalization with id, CSS and XPath fallbacks
- analyze recorded web actions to suggest stable selectors
- integrate selector analysis with web recorder and tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896f603109083279f3129a64a23b780