### PR TITLE
Add Office, Word, and Outlook automation actions

### DIFF
--- a/tests/test_actions_office.py
+++ b/tests/test_actions_office.py
@@ -17,6 +17,8 @@ def test_excel_actions(monkeypatch):
     rng = MagicMock()
     rng.Value = "old"
     sheet.Range.return_value = rng
+    cells = MagicMock()
+    sheet.Cells = cells
     wb.ActiveSheet = sheet
     app.Workbooks.Open.return_value = wb
 
@@ -35,3 +37,19 @@ def test_excel_actions(monkeypatch):
 
     office.excel_save(Step(id="save", action="excel.save", params={}), ctx)
     wb.Save.assert_called_once()
+
+    office.excel_run_macro(
+        Step(id="macro", action="excel.run_macro", params={"name": "Macro1"}), ctx
+    )
+    app.Run.assert_called_once_with("Macro1")
+
+    office.excel_export(
+        Step(id="export", action="excel.export", params={"path": "out.pdf", "format": 0}), ctx
+    )
+    wb.ExportAsFixedFormat.assert_called_once_with(0, "out.pdf")
+
+    office.excel_find_replace(
+        Step(id="fr", action="excel.find_replace", params={"find": "old", "replace": "new"}),
+        ctx,
+    )
+    cells.Replace.assert_called_once_with("old", "new")

--- a/tests/test_actions_outlook.py
+++ b/tests/test_actions_outlook.py
@@ -17,6 +17,8 @@ def test_outlook_actions(monkeypatch):
     session.OpenSharedItem.return_value = item
     app.Session = session
     app.Application.Run = MagicMock()
+    item.Send = MagicMock()
+    session.SendAndReceive = MagicMock()
     monkeypatch.setattr(outlook, "win32", MagicMock(Dispatch=lambda prog_id: app))
 
     ctx = build_ctx()
@@ -29,3 +31,11 @@ def test_outlook_actions(monkeypatch):
 
     outlook.outlook_run_macro(Step(id="macro", action="outlook.run_macro", params={"name": "Macro1"}), ctx)
     app.Application.Run.assert_called_once_with("Macro1")
+
+    outlook.outlook_send(Step(id="send", action="outlook.send", params={}), ctx)
+    item.Send.assert_called_once()
+
+    outlook.outlook_send_receive(
+        Step(id="sr", action="outlook.send_receive", params={}), ctx
+    )
+    session.SendAndReceive.assert_called_once_with(False)

--- a/workflow/actions_office.py
+++ b/workflow/actions_office.py
@@ -65,9 +65,39 @@ def excel_save(step: Step, ctx: ExecutionContext) -> Any:
     return True
 
 
+def excel_run_macro(step: Step, ctx: ExecutionContext) -> Any:
+    """Run a macro in the Excel application."""
+    macro = step.params["name"]
+    app = ctx.globals[_EXCEL_APP]
+    return app.Run(macro)
+
+
+def excel_export(step: Step, ctx: ExecutionContext) -> Any:
+    """Export the workbook to a fixed format (e.g. PDF)."""
+    wb = ctx.globals[_EXCEL_BOOK]
+    path = step.params["path"]
+    fmt = step.params.get("format", 0)
+    wb.ExportAsFixedFormat(fmt, path)
+    return path
+
+
+def excel_find_replace(step: Step, ctx: ExecutionContext) -> Any:
+    """Find and replace text in the active sheet."""
+    find = step.params["find"]
+    replace = step.params.get("replace", "")
+    sheet_name = step.params.get("sheet")
+    wb = ctx.globals[_EXCEL_BOOK]
+    sheet = wb.Worksheets(sheet_name) if sheet_name else wb.ActiveSheet
+    sheet.Cells.Replace(find, replace)
+    return replace
+
+
 OFFICE_ACTIONS = {
     "excel.open": excel_open,
     "excel.get": excel_get,
     "excel.set": excel_set,
     "excel.save": excel_save,
+    "excel.run_macro": excel_run_macro,
+    "excel.export": excel_export,
+    "excel.find_replace": excel_find_replace,
 }

--- a/workflow/actions_outlook.py
+++ b/workflow/actions_outlook.py
@@ -48,8 +48,24 @@ def outlook_run_macro(step: Step, ctx: ExecutionContext) -> Any:
     return app.Application.Run(macro)
 
 
+def outlook_send(step: Step, ctx: ExecutionContext) -> Any:
+    """Send the currently opened Outlook item."""
+    item = ctx.globals[_OUTLOOK_ITEM]
+    item.Send()
+    return True
+
+
+def outlook_send_receive(step: Step, ctx: ExecutionContext) -> Any:
+    """Trigger a send/receive operation."""
+    app = ctx.globals[_OUTLOOK_APP]
+    app.Session.SendAndReceive(False)
+    return True
+
+
 OUTLOOK_ACTIONS = {
     "outlook.open": outlook_open,
     "outlook.save": outlook_save,
     "outlook.run_macro": outlook_run_macro,
+    "outlook.send": outlook_send,
+    "outlook.send_receive": outlook_send_receive,
 }

--- a/workflow/actions_word.py
+++ b/workflow/actions_word.py
@@ -50,8 +50,45 @@ def word_run_macro(step: Step, ctx: ExecutionContext) -> Any:
     return app.Run(macro)
 
 
+def word_bookmark_set(step: Step, ctx: ExecutionContext) -> Any:
+    """Set the text of a bookmark."""
+    name = step.params["name"]
+    value = step.params.get("value", "")
+    doc = ctx.globals[_WORD_DOC]
+    if not doc.Bookmarks.Exists(name):  # type: ignore[attr-defined]
+        raise KeyError(name)
+    rng = doc.Bookmarks(name).Range
+    rng.Text = value
+    doc.Bookmarks.Add(name, rng)
+    return value
+
+
+def word_replace_all(step: Step, ctx: ExecutionContext) -> Any:
+    """Replace all occurrences of text in the document."""
+    find_text = step.params["find"]
+    replace_text = step.params.get("replace", "")
+    doc = ctx.globals[_WORD_DOC]
+    rng = doc.Content
+    find = rng.Find
+    find.Text = find_text
+    find.Replacement.Text = replace_text
+    find.Execute(Replace=2, Forward=True, Wrap=1)
+    return True
+
+
+def word_export_pdf(step: Step, ctx: ExecutionContext) -> Any:
+    """Export the document as a PDF file."""
+    path = step.params["path"]
+    doc = ctx.globals[_WORD_DOC]
+    doc.ExportAsFixedFormat(path, 17)
+    return path
+
+
 WORD_ACTIONS = {
     "word.open": word_open,
     "word.save": word_save,
     "word.run_macro": word_run_macro,
+    "word.bookmark.set": word_bookmark_set,
+    "word.replace_all": word_replace_all,
+    "word.export_pdf": word_export_pdf,
 }


### PR DESCRIPTION
## Summary
- Add Excel actions for macros, exporting, and find/replace
- Introduce Word bookmark, replace-all, and PDF export utilities
- Provide Outlook send and send/receive support

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896f7780d8883278fe54b9181ab5750