### PR TITLE
feat: add selector cycling and wait presets

### DIFF
--- a/workflow/config.py
+++ b/workflow/config.py
@@ -1,5 +1,11 @@
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import Any, Callable, Dict, List, TYPE_CHECKING
+
+from .selector import resolve as resolve_selector
+
+if TYPE_CHECKING:  # pragma: no cover - only used for type hints
+    from .flow import Step
+    from .runner import ExecutionContext
 
 
 @dataclass(frozen=True)
@@ -9,14 +15,79 @@ class ProfileConfig:
     timeoutMs: int
     retry: int
     fallback: List[str] = field(default_factory=list)
+    selectors: List[str] = field(
+        default_factory=lambda: ["uia", "anchor", "image", "coordinate"]
+    )
+
+
+# ---- waiting presets -----------------------------------------------------
+
+WaitFunc = Callable[["Step", "ExecutionContext"], bool]
+
+
+def _wait_visible(step: "Step", ctx: "ExecutionContext") -> bool:
+    selector = step.selector or step.params.get("selector") or {}
+    if not selector:
+        return True
+    try:
+        resolved = resolve_selector(selector)
+    except Exception:
+        return False
+    target = resolved.get("target")
+    if hasattr(target, "is_visible"):
+        try:
+            return bool(target.is_visible())
+        except Exception:
+            return False
+    return True
+
+
+def _wait_clickable(step: "Step", ctx: "ExecutionContext") -> bool:
+    selector = step.selector or step.params.get("selector") or {}
+    if not selector:
+        return True
+    try:
+        resolved = resolve_selector(selector)
+    except Exception:
+        return False
+    target = resolved.get("target")
+    visible = True
+    enabled = True
+    if hasattr(target, "is_visible"):
+        try:
+            visible = bool(target.is_visible())
+        except Exception:
+            visible = False
+    if hasattr(target, "is_enabled"):
+        try:
+            enabled = bool(target.is_enabled())
+        except Exception:
+            enabled = False
+    return visible and enabled
+
+
+WAIT_PRESETS: Dict[str, WaitFunc] = {
+    "visible": _wait_visible,
+    "clickable": _wait_clickable,
+}
 
 
 DEFAULT_PROFILE = "physical"
 
 # Default profile definitions. These are intentionally small so tests run quickly.
 PROFILES: Dict[str, ProfileConfig] = {
-    "physical": ProfileConfig(timeoutMs=1000, retry=0, fallback=["vdi"]),
-    "vdi": ProfileConfig(timeoutMs=2000, retry=0, fallback=[]),
+    "physical": ProfileConfig(
+        timeoutMs=1000,
+        retry=0,
+        fallback=["vdi"],
+        selectors=["uia", "anchor", "image", "coordinate"],
+    ),
+    "vdi": ProfileConfig(
+        timeoutMs=2000,
+        retry=0,
+        fallback=[],
+        selectors=["image", "coordinate", "uia", "anchor"],
+    ),
 }
 
 


### PR DESCRIPTION
## Summary
- add clickable/visible wait presets and selector order per profile
- cycle through selectors and use wait presets with exponential backoff

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896f8ced9a8832789b2ff10ebf76bf4