### PR TITLE
feat: add scheduler condition hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,22 @@ DPI(`dpi`)を指定できるようになりました。これらのパラメー�
 から選択できる `basis` パラメータと、クリックを実行せずに座標を返す
 `preview` フラグをサポートします。
 
+## 環境チェックのフック
+
+`CronScheduler.add_job` は環境を確認するための条件コールバックを
+受け取れるようになりました。例えば VPN に接続している場合のみ
+ジョブを実行したいときは以下のように指定します。
+
+```python
+from workflow.scheduler import CronScheduler
+
+def is_vpn_connected():
+    # 実際のチェックは環境に合わせて実装
+    return True
+
+s = CronScheduler()
+s.add_job("0 * * * * *", job, "job.lock", conditions=[is_vpn_connected])
+```
+
+条件関数が `False` を返した場合、そのジョブはスキップされます。
+

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -49,3 +49,20 @@ def test_crash_report_creation(tmp_path):
     assert data["error"] == "boom"
     assert "python" in data["env"]
     assert "before crash" in data["log"]
+
+
+def test_condition_callbacks_skip_job(tmp_path):
+    called = False
+
+    def job():
+        nonlocal called
+        called = True
+
+    def check():
+        return False
+
+    s = CronScheduler()
+    s.add_job("* * * * * *", job, tmp_path / "lock", conditions=[check])
+    s.run_pending(datetime.now())
+
+    assert not called


### PR DESCRIPTION
## Summary
- allow CronScheduler jobs to specify environment condition callbacks
- skip job execution when a condition evaluates to false
- document scheduler environment-check hooks and add tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68970732dce08327a46a1796d73585da