### PR TITLE
feat: enhance GUI tool helpers

### DIFF
--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -12,20 +12,46 @@ def test_capture_coordinates_basis_preview(monkeypatch):
 
     dummy_cursor = types.SimpleNamespace(pos=lambda: DummyPos())
     monkeypatch.setattr(gui_tools, "QCursor", dummy_cursor)
+    monkeypatch.setattr(gui_tools, "_screen_dpi", lambda: 120)
+    monkeypatch.setattr(gui_tools, "_grab_preview", lambda x, y: (x, y))
 
     res_screen = gui_tools.capture_coordinates()
-    assert res_screen == {"x": 100, "y": 200, "basis": "Screen"}
+    assert res_screen == {"x": 100, "y": 200, "basis": "Screen", "dpi": 120}
 
     res_elem = gui_tools.capture_coordinates(basis="Element", origin=(90, 190))
-    assert res_elem["x"] == 10 and res_elem["y"] == 10 and res_elem["basis"] == "Element"
+    assert (
+        res_elem["x"] == 10
+        and res_elem["y"] == 10
+        and res_elem["basis"] == "Element"
+        and res_elem["dpi"] == 120
+    )
 
     res_preview = gui_tools.capture_coordinates(preview=True)
     assert res_preview["preview"] == (100, 200)
+    assert res_preview["dpi"] == 120
 
 
-def test_record_web_suggests_stable_selectors():
-    actions = [{"selector": "button#save"}]
-    result = gui_tools.record_web(actions)
+def test_element_spy_highlight_and_anchor(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(
+        gui_tools, "highlight_screen", lambda sel: calls.append(("highlight", sel))
+    )
+    monkeypatch.setattr(
+        gui_tools, "register_anchor", lambda sel: calls.append(("anchor", sel))
+    )
+
+    info = gui_tools.element_spy("#login")
+    assert info.selector == "#login"
+    assert ("highlight", "#login") in calls
+    assert ("anchor", "#login") in calls
+
+
+def test_record_web_normalises_and_wires():
+    flow = {"steps": [{"id": "a", "action": "click"}]}
+    actions = [{"id": "a", "selector": "button#save"}]
+    result = gui_tools.record_web(actions, flow)
     suggestions = result[0]["selectorSuggestions"]
     assert suggestions[0] == "[data-testid=\"save\"]"
-    assert "#save" in suggestions
+    assert result[0]["selector"] == "[data-testid=\"save\"]"
+    assert flow["steps"][0]["params"]["selector"] == "[data-testid=\"save\"]"


### PR DESCRIPTION
## Summary
- add highlight and anchor registration to element_spy
- make capture_coordinates DPI aware with preview support
- normalise selectors and wire into flows when recording web actions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68970f5aa09c83279ec26d9798f7a75b