### PR TITLE
Add optional UIA tree and web trace capture on errors

### DIFF
--- a/workflow/logging.py
+++ b/workflow/logging.py
@@ -46,7 +46,7 @@ def log_step(
         "result": result,
     }
     record.update(extra)
-    unmasked = {"runId", "stepId", "action", "screenshot", "uiTree"}
+    unmasked = {"runId", "stepId", "action", "screenshot", "uiTree", "webTrace"}
     for k, v in list(record.items()):
         if k not in unmasked and isinstance(v, str):
             record[k] = mask_pii(v)


### PR DESCRIPTION
## Summary
- support capturing UIA tree and web trace artifacts when `onError` requests them
- include web trace in unmasked log fields
- test new on-error artifact capture paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897159eb52c83278f105cee87c164ed