### PR TITLE
Add validation for extended variable types

### DIFF
--- a/tests/test_var_types.py
+++ b/tests/test_var_types.py
@@ -1,0 +1,39 @@
+import pytest
+from datetime import date
+from pathlib import Path
+
+from workflow.flow import Flow, Meta, VarDef
+from workflow.runner import ExecutionContext
+
+
+@pytest.mark.parametrize(
+    "vtype,value",
+    [
+        ("date", "2024-01-01"),
+        ("path", 123),
+        ("secret", 123),
+        ("array", {"a": 1}),
+        ("object", [1, 2, 3]),
+    ],
+)
+def test_type_error_on_assignment(vtype, value):
+    flow = Flow(version="1", meta=Meta(name="t"), variables={"x": VarDef(type=vtype, value=None)})
+    ctx = ExecutionContext(flow, {})
+    with pytest.raises(TypeError):
+        ctx.set_var("x", value)
+
+
+@pytest.mark.parametrize(
+    "vtype,value",
+    [
+        ("date", date(2024, 1, 1)),
+        ("path", Path("/tmp")),
+        ("secret", "abc"),
+        ("array", [1, 2]),
+        ("object", {"a": 1}),
+    ],
+)
+def test_valid_assignment(vtype, value):
+    flow = Flow(version="1", meta=Meta(name="t"), variables={"x": VarDef(type=vtype, value=None)})
+    ctx = ExecutionContext(flow, {})
+    ctx.set_var("x", value)

--- a/workflow/flow.py
+++ b/workflow/flow.py
@@ -1,4 +1,22 @@
-"""Data models for workflow definition."""
+"""Data models for workflow definition.
+
+The classes in this module mirror the JSON structure used to describe a
+workflow.  Variables are declared with :class:`VarDef` which supports a
+small set of primitive types as well as a few convenience types.
+
+Example
+-------
+>>> from datetime import date
+>>> from pathlib import Path
+>>> flow = Flow(
+...     version="1",
+...     meta=Meta(name="demo"),
+...     variables={
+...         "today": VarDef(type="date", value=date.today()),
+...         "out": VarDef(type="path", value=Path("/tmp")),
+...     },
+... )
+"""
 
 from __future__ import annotations
 
@@ -31,7 +49,21 @@ class Defaults:
 
 @dataclass
 class VarDef:
-    """Definition of a flow variable including its type and default value."""
+    """Definition of a flow variable including its type and default value.
+
+    Parameters
+    ----------
+    type:
+        Name of the variable type. Supported values are ``int``, ``float``,
+        ``str``, ``bool``, ``date``, ``path``, ``secret``, ``array``, ``object``
+        and ``any``. ``date`` accepts :class:`datetime.date` or
+        :class:`datetime.datetime` objects; ``path`` accepts strings or
+        :class:`pathlib.Path`; ``array`` maps to :class:`list`; ``object`` maps
+        to :class:`dict`; ``secret`` behaves like ``str`` but marks the value as
+        sensitive.
+    value:
+        Default value for the variable.
+    """
 
     type: str = "any"
     value: Any = None

--- a/workflow/runner.py
+++ b/workflow/runner.py
@@ -7,6 +7,7 @@ import time
 import os
 import fcntl
 from dataclasses import dataclass, field
+from datetime import date, datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, IO, List, Optional, Set
 
@@ -80,7 +81,17 @@ class ExecutionContext:
         self._check_write(name)
         expected = self.var_types.get(name)
         if expected and expected != "any":
-            type_map = {"int": int, "float": float, "str": str, "bool": bool}
+            type_map = {
+                "int": int,
+                "float": float,
+                "str": str,
+                "bool": bool,
+                "date": (datetime, date),
+                "path": (str, Path),
+                "secret": str,
+                "array": list,
+                "object": dict,
+            }
             py_type = type_map.get(expected)
             if py_type and not isinstance(value, py_type):
                 raise TypeError(f"Variable '{name}' expects {expected}")


### PR DESCRIPTION
## Summary
- expand `ExecutionContext.set_var` to check `date`, `path`, `secret`, `array` and `object`
- document new variable types and `VarDef` usage with examples
- test type checking for these additional variable types

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897190bae708327ab0638efe3ed2094