### PR TITLE
Add select and upload web actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,21 @@ python rpa_main_ui.py
 同時に複数のフローが動作しないようにしています。実行が終了するか `stop()`
 が呼び出されるとロックは解放され、ファイルも削除されます。
 
+## Web アクション
+
+Playwright を利用した Web ページ操作用のアクションをサポートしています。  
+利用可能なアクションの例:
+
+- `open`
+- `click`
+- `fill`
+- `select`
+- `upload`
+- `wait_for`
+- `download`
+- `evaluate`
+- `screenshot`
+
 ## 画像検索と座標の拡張
 
 `find_image` アクションはスケール(`scale`)、色の許容度(`tolerance`)、


### PR DESCRIPTION
## Summary
- implement `select` and `upload` Playwright helpers
- register new actions and document Web action usage
- cover selection and file upload with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68972ac5305483279abe5c5715c7c324