### PR TITLE
Add package signing utilities and self-update with rollback

### DIFF
--- a/tests/test_package_utils.py
+++ b/tests/test_package_utils.py
@@ -1,5 +1,11 @@
 from pathlib import Path
-from workflow.package_utils import sign_package, verify_package
+from workflow.package_utils import (
+    extract_package,
+    rollback_update,
+    self_update,
+    sign_package,
+    verify_package,
+)
 
 
 def test_sign_and_verify(tmp_path: Path):
@@ -9,3 +15,40 @@ def test_sign_and_verify(tmp_path: Path):
     sign_package(pkg, key)
     assert verify_package(pkg, key) is True
     assert verify_package(pkg, b"wrong") is False
+
+
+def test_extract_package(tmp_path: Path):
+    src = tmp_path / "pkg"
+    src.mkdir()
+    (src / "file.txt").write_text("ok")
+    key = b"k"
+    sign_package(src, key)
+    zip_path = src.with_suffix(".zip")
+    dest = extract_package(zip_path, key)
+    assert (dest / "file.txt").read_text() == "ok"
+
+
+def test_self_update_and_rollback(tmp_path: Path):
+    # set up existing installation
+    install = tmp_path / "app"
+    install.mkdir()
+    (install / "old.txt").write_text("old")
+
+    # create new signed package
+    new_pkg_dir = tmp_path / "new"
+    new_pkg_dir.mkdir()
+    (new_pkg_dir / "new.txt").write_text("new")
+    key = b"secret"
+    sign_package(new_pkg_dir, key)
+    pkg_zip = new_pkg_dir.with_suffix(".zip")
+
+    # use file:// URL for "download"
+    url = pkg_zip.as_uri()
+    assert self_update(url, install, key) is True
+    assert (install / "new.txt").read_text() == "new"
+    backup = install.with_suffix(".bak")
+    assert (backup / "old.txt").read_text() == "old"
+
+    # rollback
+    assert rollback_update(install) is True
+    assert (install / "old.txt").read_text() == "old"

--- a/workflow/package_utils.py
+++ b/workflow/package_utils.py
@@ -1,12 +1,15 @@
-"""Utilities to sign and verify flow packages."""
+"""Utilities to sign, verify and apply signed workflow packages."""
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Union
+from typing import Optional, Union
 import hashlib
 import hmac
 import io
 import zipfile
+import urllib.request
+import tempfile
+import shutil
 
 PathLike = Union[str, Path]
 
@@ -69,4 +72,98 @@ def verify_package(path: PathLike, key: bytes) -> bool:
     return hmac.compare_digest(expected, actual)
 
 
-__all__ = ["sign_package", "verify_package"]
+def extract_package(path: PathLike, key: bytes, target: Optional[PathLike] = None) -> Path:
+    """Extract a signed ZIP package after verifying its signature.
+
+    Parameters
+    ----------
+    path:
+        Path to the ``.zip`` package to extract.
+    key:
+        HMAC key used for signature verification.
+    target:
+        Optional directory to extract into.  When omitted a temporary
+        directory is created and returned.
+
+    Returns
+    -------
+    Path
+        Directory containing the extracted package contents.
+
+    Raises
+    ------
+    ValueError
+        If signature verification fails.
+    """
+
+    p = Path(path)
+    if not verify_package(p, key):
+        raise ValueError("invalid package signature")
+
+    if target is None:
+        tmpdir = tempfile.mkdtemp()
+        dest = Path(tmpdir)
+    else:
+        dest = Path(target)
+        dest.mkdir(parents=True, exist_ok=True)
+
+    with zipfile.ZipFile(p) as zf:
+        zf.extractall(dest)
+    return dest
+
+
+def self_update(package_url: str, install_dir: PathLike, key: bytes) -> bool:
+    """Download, verify and apply a signed package.
+
+    ``package_url`` should point to the ``.zip`` archive.  A corresponding
+    ``.sig`` file is fetched by appending ``.sig`` to the URL.  On successful
+    verification the archive is extracted and its contents replace
+    ``install_dir``.  The previous installation is kept in ``.bak`` for
+    potential rollback.
+    """
+
+    with tempfile.TemporaryDirectory() as tmp:
+        pkg_path = Path(tmp) / "update.zip"
+        sig_path = _sig_path(pkg_path)
+
+        with urllib.request.urlopen(package_url) as resp:
+            pkg_path.write_bytes(resp.read())
+        with urllib.request.urlopen(package_url + ".sig") as resp:
+            sig_path.write_bytes(resp.read())
+
+        if not verify_package(pkg_path, key):
+            return False
+
+        extract_dir = Path(tmp) / "extracted"
+        with zipfile.ZipFile(pkg_path) as zf:
+            zf.extractall(extract_dir)
+
+        dest = Path(install_dir)
+        backup = dest.with_suffix(dest.suffix + ".bak")
+        if backup.exists():
+            shutil.rmtree(backup)
+        if dest.exists():
+            dest.rename(backup)
+        shutil.copytree(extract_dir, dest)
+    return True
+
+
+def rollback_update(install_dir: PathLike) -> bool:
+    """Restore the previous installation if a backup exists."""
+    dest = Path(install_dir)
+    backup = dest.with_suffix(dest.suffix + ".bak")
+    if not backup.exists():
+        return False
+    if dest.exists():
+        shutil.rmtree(dest)
+    backup.rename(dest)
+    return True
+
+
+__all__ = [
+    "sign_package",
+    "verify_package",
+    "extract_package",
+    "self_update",
+    "rollback_update",
+]


### PR DESCRIPTION
## Summary
- extend `package_utils` with extraction verifying signatures
- add self-update helper to download and apply signed packages with rollback
- cover new utilities with tests

## Testing
- `pytest tests/test_package_utils.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68972d1554c08327afe533c53a8a3994