### PR TITLE
Enhance element spy to expose UI metadata

### DIFF
--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -41,10 +41,16 @@ def test_element_spy_highlight_and_anchor(monkeypatch):
         gui_tools, "register_anchor", lambda sel: calls.append(("anchor", sel))
     )
 
-    info = gui_tools.element_spy("#login")
+    info = gui_tools.element_spy("#login", text="Login")
     assert info.selector == "#login"
+    assert info.automation_id and info.name and info.control_type and info.class_name
+    assert isinstance(info.hierarchy, list)
     assert ("highlight", "#login") in calls
     assert ("anchor", "#login") in calls
+
+    rows = gui_tools.format_spy_result(info)
+    keys = [k for k, _ in rows]
+    assert "AutomationId" in keys and "Hierarchy" in keys
 
 
 def test_record_web_normalises_and_wires():

--- a/workflow/gui_tools.py
+++ b/workflow/gui_tools.py
@@ -87,19 +87,81 @@ class ElementInfo:
 
     selector: str
     text: str | None = None
+    automation_id: str | None = None
+    name: str | None = None
+    control_type: str | None = None
+    class_name: str | None = None
+    hierarchy: List[Dict[str, str]] | None = None
 
 
 def element_spy(selector: str, text: str | None = None) -> ElementInfo:
-    """Simulate an element spy utility.
+    """Simulate an element spy utility collecting basic UIA data.
 
     In addition to recording the selector, the function highlights the element
-    on screen and registers it as an anchor.  Both behaviours are stubs that can
-    be monkeypatched in tests.
+    on screen and registers it as an anchor.  ``AutomationId``, ``Name``,
+    ``ControlType`` and ``ClassName`` are synthesised for test purposes.  A
+    simple parent hierarchy is also returned so that GUI components can present
+    the element in context.  Real implementations would query these details
+    from the accessibility framework.
     """
 
     highlight_screen(selector)
     register_anchor(selector)
-    return ElementInfo(selector=selector, text=text)
+
+    # placeholder data allowing callers to exercise the structure of the
+    # returned information.  In unit tests this can be monkeypatched to provide
+    # deterministic values.
+    automation_id = f"{selector}-auto"
+    name = text or selector
+    control_type = "Control"
+    class_name = "Generic"
+    hierarchy = [
+        {
+            "automation_id": automation_id,
+            "name": name,
+            "control_type": control_type,
+            "class_name": class_name,
+        }
+    ]
+
+    return ElementInfo(
+        selector=selector,
+        text=text,
+        automation_id=automation_id,
+        name=name,
+        control_type=control_type,
+        class_name=class_name,
+        hierarchy=hierarchy,
+    )
+
+
+def format_spy_result(info: ElementInfo) -> List[Tuple[str, str]]:
+    """Return ``info`` formatted for presentation in a GUI table.
+
+    The function converts the dataclass into a list of ``(label, value)`` tuples
+    which can be easily rendered by GUI toolkits without understanding the
+    dataclass structure.  It also flattens the hierarchy into a single string to
+    keep the representation simple.
+    """
+
+    rows: List[Tuple[str, str]] = [
+        ("Selector", info.selector),
+        ("AutomationId", info.automation_id or ""),
+        ("Name", info.name or ""),
+        ("ControlType", info.control_type or ""),
+        ("ClassName", info.class_name or ""),
+    ]
+
+    if info.text is not None:
+        rows.append(("Text", info.text))
+
+    if info.hierarchy:
+        chain = " > ".join(
+            h.get("name") or h.get("automation_id") or "?" for h in info.hierarchy
+        )
+        rows.append(("Hierarchy", chain))
+
+    return rows
 
 
 def capture_coordinates(


### PR DESCRIPTION
## Summary
- expand element spy to return AutomationId, Name, ControlType, ClassName and hierarchy
- add helper to format spy results for GUI presentation
- update tests for new element spy data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68972e8b03f4832780bfa2cf7c0503a4