### PR TITLE
feat: emit recorded web actions to callbacks

### DIFF
--- a/tests/test_gui_tools.py
+++ b/tests/test_gui_tools.py
@@ -1,4 +1,5 @@
 import types
+import queue
 from workflow import gui_tools
 
 
@@ -61,3 +62,18 @@ def test_record_web_normalises_and_wires():
     assert suggestions[0] == "[data-testid=\"save\"]"
     assert result[0]["selector"] == "[data-testid=\"save\"]"
     assert flow["steps"][0]["params"]["selector"] == "[data-testid=\"save\"]"
+
+
+def test_record_web_insert_callback_and_queue():
+    q: queue.Queue = queue.Queue()
+    calls: list[dict] = []
+    actions = [{"selector": "button#ok"}]
+    gui_tools.record_web(
+        actions,
+        insert=True,
+        callback=lambda a: calls.append(a),
+        queue=q,
+    )
+    assert calls[0]["selector"].startswith("[data-testid=")
+    queued = q.get_nowait()
+    assert queued["selector"] == calls[0]["selector"]


### PR DESCRIPTION
## Summary
- extend `record_web` to optionally emit processed actions via callback or queue
- add queue polling and callback in mock UI to insert new steps
- cover new behavior with tests

## Testing
- `pytest tests/test_gui_tools.py::test_record_web_insert_callback_and_queue -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68972f7b6f248327b88d2d69fa61c55f