### PR TITLE
feat: customize selector fallback

### DIFF
--- a/tests/test_selector_fallback.py
+++ b/tests/test_selector_fallback.py
@@ -1,0 +1,44 @@
+from workflow.flow import Defaults, Flow, Meta, Step
+from workflow.runner import Runner
+import workflow.config as cfg
+
+
+def _make_action(attempts):
+    def action(step, ctx):
+        # step.selector is a dict with single strategy name
+        name = next(iter(step.selector)) if step.selector else None
+        attempts.append(name)
+        if name == "uia":
+            return "ok"
+        raise RuntimeError("fail")
+    return action
+
+
+def test_selector_order_and_retry(monkeypatch):
+    # ensure profile retry/timeouts do not interfere
+    monkeypatch.setitem(
+        cfg.PROFILES,
+        "physical",
+        cfg.ProfileConfig(timeoutMs=100, retry=0, fallback=[]),
+    )
+    attempts = []
+    runner = Runner()
+    runner.register_action("test", _make_action(attempts))
+    flow = Flow(
+        version="1.0",
+        meta=Meta(name="sel"),
+        defaults=Defaults(envProfile="physical"),
+        steps=[
+            Step(
+                id="s",
+                action="test",
+                selector={"uia": 1, "image": 2},
+                selectorOrder=["image", "uia"],
+                selectorRetry=1,
+                out="r",
+            )
+        ],
+    )
+    result = runner.run_flow(flow, {})
+    assert result["r"] == "ok"
+    assert attempts == ["image", "image", "uia"]

--- a/workflow/flow.py
+++ b/workflow/flow.py
@@ -79,6 +79,8 @@ class Step:
     id: str
     action: Optional[str] = None
     selector: Optional[Dict[str, Any]] = None
+    selectorOrder: List[str] = field(default_factory=list)
+    selectorRetry: Optional[int] = None
     target: Optional[Dict[str, Any]] = None
     params: Dict[str, Any] = field(default_factory=dict)
     waitFor: Optional[str] = None
@@ -124,6 +126,8 @@ class Flow:
                 id=sd.get("id", ""),
                 action=sd.get("action"),
                 selector=sd.get("selector"),
+                selectorOrder=sd.get("selectorOrder", []),
+                selectorRetry=sd.get("selectorRetry"),
                 target=sd.get("target"),
                 params=sd.get("params", {}),
                 waitFor=sd.get("waitFor"),

--- a/workflow/runner.py
+++ b/workflow/runner.py
@@ -458,13 +458,16 @@ class Runner:
 
             selectors = [original_selector]
             if isinstance(original_selector, dict):
-                ordered = [s for s in profile.selectors if s in original_selector]
+                order = step.selectorOrder or profile.selectors
+                ordered = [s for s in order if s in original_selector]
                 if ordered:
                     selectors = [{name: original_selector[name]} for name in ordered]
 
+            selector_retry = step.selectorRetry if step.selectorRetry is not None else retry
+
             for sel in selectors:
                 step.selector = sel
-                for attempt in range(retry + 1):
+                for attempt in range(selector_retry + 1):
                     start = time.time()
                     ctx.globals["profile"] = pname
                     try:
@@ -552,7 +555,7 @@ class Runner:
                             ctx.pop_local()
                             step.selector = original_selector
                             return
-                        if attempt == retry:
+                        if attempt == selector_retry:
                             break
                         time.sleep(0.1 * (2 ** attempt))
             step.selector = original_selector


### PR DESCRIPTION
## Summary
- allow flow steps to specify `selectorOrder` and `selectorRetry`
- runner uses these settings to control selector fallback order and retries
- cover selector fallback behavior with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689741acaa7c8327b5b556645c084ec6