### PR TITLE
Add signing utilities, approval checks, and screenshot masking

### DIFF
--- a/tests/test_flow_signature.py
+++ b/tests/test_flow_signature.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from workflow.flow_signature import sign_flow, verify_flow
+
+
+def test_sign_and_verify(tmp_path):
+    flow_dir = tmp_path / "flow"
+    flow_dir.mkdir()
+    (flow_dir / "file.txt").write_text("data")
+    key = b"secret"
+    sig = sign_flow(flow_dir, key)
+    assert sig
+    zip_path = flow_dir.with_suffix(flow_dir.suffix + ".zip")
+    assert zip_path.exists()
+    assert verify_flow(zip_path, key)

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -14,5 +14,5 @@ def test_runner_requires_role(monkeypatch):
     monkeypatch.setattr(builtins, "input", lambda prompt="": "y")
     with pytest.raises(PermissionError):
         runner.run_flow(flow, {})
-    result = runner.run_flow(flow, {"roles": ["user"]})
+    result = runner.run_flow(flow, {"roles": ["user"], "approval_level": 1})
     assert result["ans"] == "y"

--- a/tests/test_screenshot_mask.py
+++ b/tests/test_screenshot_mask.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from workflow.flow import Flow, Meta, Step
+from workflow.runner import ExecutionContext, Runner
+from workflow import hooks
+
+
+def test_screenshot_mask_hook(tmp_path):
+    flow = Flow(version="1", meta=Meta(name="t"))
+    ctx = ExecutionContext(flow, {})
+    runner = Runner(base_dir=tmp_path)
+
+    def masker(data: bytes) -> bytes:
+        return b"masked"
+
+    hooks.screenshot_mask_hook = masker
+    try:
+        artifacts = runner._capture_artifacts(Step(id="s", action="a"), Exception("boom"))
+        shot_path = Path(artifacts["screenshot"])
+        assert shot_path.read_bytes() == b"masked"
+    finally:
+        hooks.screenshot_mask_hook = None

--- a/workflow/actions_web.py
+++ b/workflow/actions_web.py
@@ -19,6 +19,7 @@ except Exception:  # pragma: no cover - optional dependency
 from .flow import Step
 from .runner import ExecutionContext
 from .selector import normalize_selector
+from .hooks import apply_screenshot_mask
 
 _PW_KEY = "_playwright"
 _BROWSER_KEY = "_browser"
@@ -375,11 +376,14 @@ def screenshot(step: Step, ctx: ExecutionContext) -> Any:
                 break
         else:
             target = page.locator(selector)
-        img = target.screenshot(path=path)
+        img = target.screenshot()
     else:
-        img = page.screenshot(path=path, full_page=full_page)
+        img = page.screenshot(full_page=full_page)
+
+    img = apply_screenshot_mask(img)
 
     if path:
+        Path(path).write_bytes(img)
         return path
     # When no path is provided return the size of the screenshot in bytes to
     # avoid sending large binary data through the workflow output.

--- a/workflow/flow_signature.py
+++ b/workflow/flow_signature.py
@@ -1,0 +1,27 @@
+"""Helpers to sign and verify workflow packages."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+
+from .package_utils import sign_package, verify_package
+
+PathLike = Union[str, Path]
+
+
+def sign_flow(path: PathLike, key: bytes) -> str:
+    """Sign the workflow located at ``path``.
+
+    Directories are zipped in a deterministic manner prior to signing.  The
+    resulting ``.sig`` file is written alongside the target.  Returns the
+    hexadecimal signature string.
+    """
+    return sign_package(path, key)
+
+
+def verify_flow(path: PathLike, key: bytes) -> bool:
+    """Verify the signature of the workflow at ``path``."""
+    return verify_package(path, key)
+
+
+__all__ = ["sign_flow", "verify_flow"]

--- a/workflow/hooks.py
+++ b/workflow/hooks.py
@@ -1,0 +1,33 @@
+"""Common hooks for the workflow runtime.
+
+Currently only provides a screenshot masking hook that allows callers to
+anonymise screenshots before they are written to disk.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+
+ScreenshotMaskHook = Callable[[bytes], bytes]
+"""Callable type for screenshot masking."""
+
+# Global hook that can be set by applications to mask screenshot bytes before
+# they are persisted. When ``None`` no masking is performed.
+screenshot_mask_hook: Optional[ScreenshotMaskHook] = None
+
+
+def apply_screenshot_mask(data: bytes) -> bytes:
+    """Return ``data`` after applying :data:`screenshot_mask_hook`.
+
+    If the hook raises an exception the original data is returned unchanged.
+    """
+    if screenshot_mask_hook is None:
+        return data
+    try:
+        return screenshot_mask_hook(data)
+    except Exception:
+        return data
+
+
+__all__ = ["screenshot_mask_hook", "apply_screenshot_mask"]

--- a/workflow/updater.py
+++ b/workflow/updater.py
@@ -1,0 +1,63 @@
+"""Self-update utilities with version checks and signed packages."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+import urllib.request
+import tempfile
+import zipfile
+import shutil
+
+from .package_utils import verify_package
+
+PathLike = Union[str, Path]
+
+
+def check_version(version_url: str) -> str:
+    """Fetch and return the latest version string from ``version_url``."""
+    with urllib.request.urlopen(version_url) as resp:
+        return resp.read().decode().strip()
+
+
+def apply_update(
+    version_url: str,
+    package_url: str,
+    install_dir: PathLike,
+    current_version: str,
+    key: bytes,
+) -> bool:
+    """Check for an update and apply it if available.
+
+    The function fetches the latest version from ``version_url``.  When the
+    version differs from ``current_version`` a signed ZIP package is downloaded
+    from ``package_url`` and verified using ``key``.  The extracted contents are
+    then copied over ``install_dir``.
+    """
+    latest = check_version(version_url)
+    if latest == current_version:
+        return False
+
+    with tempfile.TemporaryDirectory() as tmp:
+        pkg = Path(tmp) / "update.zip"
+        sig = pkg.with_suffix(pkg.suffix + ".sig")
+        with urllib.request.urlopen(package_url) as resp:
+            pkg.write_bytes(resp.read())
+        with urllib.request.urlopen(package_url + ".sig") as resp:
+            sig.write_bytes(resp.read())
+        if not verify_package(pkg, key):
+            return False
+        extract_dir = Path(tmp) / "extracted"
+        with zipfile.ZipFile(pkg) as zf:
+            zf.extractall(extract_dir)
+        dest = Path(install_dir)
+        for src in extract_dir.rglob("*"):
+            dest_path = dest / src.relative_to(extract_dir)
+            if src.is_dir():
+                dest_path.mkdir(parents=True, exist_ok=True)
+            else:
+                dest_path.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, dest_path)
+    return True
+
+
+__all__ = ["check_version", "apply_update"]


### PR DESCRIPTION
## Summary
- add hook system for masking screenshots
- enforce role and approval level checks in `ExecutionContext`
- add modules for flow package signing and self-update

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689745c9de4c8327bf8112dcfa52ba29