### PR TITLE
Add integration and failure injection tests with nightly regression

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,4 +18,4 @@ jobs:
           python -m pip install --upgrade pip
           pip install pytest
       - name: Run tests
-        run: pytest
+        run: pytest -m regression

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    regression: integration regression tests for nightly runs

--- a/tests/test_failure_injection.py
+++ b/tests/test_failure_injection.py
@@ -1,0 +1,59 @@
+import pytest
+
+from workflow.actions import BUILTIN_ACTIONS
+from workflow.flow import Flow, Meta, Step
+from workflow.runner import Runner
+
+from tests.mocks.mock_dom import MockDOM
+from tests.mocks.mock_network import MockNetwork
+
+
+DOM = MockDOM()
+NETWORK = MockNetwork()
+
+
+def _build_runner() -> Runner:
+    runner = Runner()
+    for name, func in BUILTIN_ACTIONS.items():
+        runner.register_action(name, func)
+    runner.register_action("dom.change", lambda step, ctx: DOM.change(step.params["value"]))
+    runner.register_action("dom.read", lambda step, ctx: DOM.query())
+    runner.register_action("network.get", lambda step, ctx: NETWORK.get(step.params["url"]))
+    return runner
+
+
+@pytest.mark.regression
+def test_dom_change_injection():
+    runner = _build_runner()
+    DOM.text = "before"
+    flow = Flow(
+        version="1.0",
+        meta=Meta(name="dom"),
+        steps=[
+            Step(id="c", action="dom.change", params={"value": "after"}),
+            Step(id="r", action="dom.read", out="text"),
+        ],
+    )
+    result = runner.run_flow(flow, {})
+    assert result["text"] == "after"
+
+
+@pytest.mark.regression
+def test_network_disconnection_injection():
+    runner = _build_runner()
+    NETWORK.fail = True
+    flow = Flow(
+        version="1.0",
+        meta=Meta(name="net"),
+        steps=[
+            Step(
+                id="n",
+                action="network.get",
+                params={"url": "http://example.com"},
+                out="data",
+            ),
+        ],
+    )
+    with pytest.raises(ConnectionError):
+        runner.run_flow(flow, {})
+    NETWORK.fail = False

--- a/tests/test_integration_profiles.py
+++ b/tests/test_integration_profiles.py
@@ -1,0 +1,59 @@
+import sys
+import types
+import pytest
+
+from workflow.flow import Flow, Meta, Defaults, Step
+from workflow.runner import Runner
+from workflow import actions
+from workflow import gui_tools
+
+
+@pytest.mark.parametrize(
+    "profile,dpi,lang",
+    [
+        ("physical", 96, "eng"),
+        ("vdi", 120, "jpn"),
+    ],
+)
+def test_environment_integration(monkeypatch, profile, dpi, lang):
+    """Run a minimal flow ensuring DPI, language and profile are respected."""
+
+    # Force a deterministic DPI value
+    monkeypatch.setattr(gui_tools, "_screen_dpi", lambda: dpi)
+
+    # Provide a fake OCR backend that echoes the requested language
+    pytesseract = types.SimpleNamespace(
+        image_to_string=lambda img, lang=None: f"text-{lang}"
+    )
+    sys.modules["pytesseract"] = pytesseract
+
+    # Avoid file system access when opening images
+    monkeypatch.setattr("PIL.Image.open", lambda path: object())
+
+    runner = Runner()
+
+    # Register helper actions
+    runner.register_action("coords", lambda step, ctx: gui_tools.capture_coordinates())
+    runner.register_action("ocr", actions.ocr_read)
+    runner.register_action("current_profile", lambda step, ctx: ctx.globals["profile"])
+
+    flow = Flow(
+        version="1.0",
+        meta=Meta(name="integration"),
+        defaults=Defaults(envProfile=profile),
+        steps=[
+            Step(id="c", action="coords", out="coords"),
+            Step(
+                id="o",
+                action="ocr",
+                params={"path": "dummy.png", "lang": lang},
+                out="text",
+            ),
+            Step(id="p", action="current_profile", out="profile"),
+        ],
+    )
+
+    result = runner.run_flow(flow, {})
+    assert result["coords"]["dpi"] == dpi
+    assert result["text"] == f"text-{lang}"
+    assert result["profile"] == profile

--- a/tests/test_regression_flows.py
+++ b/tests/test_regression_flows.py
@@ -8,6 +8,8 @@ from workflow.runner import Runner
 from tests.mocks.mock_dom import MockDOM
 from tests.mocks.mock_network import MockNetwork
 
+pytestmark = pytest.mark.regression
+
 DOM = MockDOM()
 NETWORK = MockNetwork()
 


### PR DESCRIPTION
## Summary
- add parameterized integration tests for DPI, language and VDI profiles
- implement DOM-change and network-disconnection failure injection tests
- configure regression test marker and nightly GitHub Actions workflow

## Testing
- `pytest tests/test_integration_profiles.py tests/test_failure_injection.py tests/test_regression_flows.py`
- `pytest -m regression`


------
https://chatgpt.com/codex/tasks/task_e_68974b01ebd483278a33e326ad13393d