### PR TITLE
Add HTTP and file workflow actions

### DIFF
--- a/tests/test_action_permissions.py
+++ b/tests/test_action_permissions.py
@@ -75,6 +75,6 @@ def test_file_permission(tmp_path):
         runner.run_flow(flow, {})
 
     runner.register_action("file.read", lambda step, ctx: True)
-    flow_ok = Flow(version="1", meta=Meta(name="t", permissions=["file"]), steps=[step])
+    flow_ok = Flow(version="1", meta=Meta(name="t", permissions=["files"]), steps=[step])
     assert runner.run_flow(flow_ok, {}) == {}
 

--- a/tests/test_actions_files.py
+++ b/tests/test_actions_files.py
@@ -1,0 +1,26 @@
+from workflow.flow import Flow, Meta, Step
+from workflow.runner import ExecutionContext
+from workflow.actions_files import file_read, file_write, file_copy, file_move, file_delete
+
+
+def build_ctx():
+    flow = Flow(version="1", meta=Meta(name="t"), steps=[])
+    return ExecutionContext(flow, {})
+
+
+def test_file_actions(tmp_path):
+    ctx = build_ctx()
+    src = tmp_path / "src.txt"
+    dst = tmp_path / "dst.txt"
+    moved = tmp_path / "moved.txt"
+    file_write(Step(id="w", action="file.write", params={"path": str(src), "content": "hi"}), ctx)
+    assert src.read_text() == "hi"
+    content = file_read(Step(id="r", action="file.read", params={"path": str(src)}), ctx)
+    assert content == "hi"
+    file_copy(Step(id="c", action="file.copy", params={"src": str(src), "dst": str(dst)}), ctx)
+    assert dst.read_text() == "hi"
+    file_move(Step(id="m", action="file.move", params={"src": str(dst), "dst": str(moved)}), ctx)
+    assert moved.read_text() == "hi"
+    assert not dst.exists()
+    file_delete(Step(id="d", action="file.delete", params={"path": str(moved)}), ctx)
+    assert not moved.exists()

--- a/tests/test_actions_http.py
+++ b/tests/test_actions_http.py
@@ -1,0 +1,58 @@
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from workflow.flow import Flow, Meta, Step
+from workflow.runner import ExecutionContext
+from workflow.actions_http import http_get, http_post
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"msg": "ok"}).encode())
+
+    def do_POST(self):  # noqa: N802
+        length = int(self.headers.get("Content-Length", 0))
+        data = json.loads(self.rfile.read(length) or b"{}")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps({"echo": data}).encode())
+
+    def log_message(self, format, *args):  # noqa: A003
+        pass
+
+
+def build_ctx():
+    flow = Flow(version="1", meta=Meta(name="t"), steps=[])
+    return ExecutionContext(flow, {})
+
+
+def run_server(server: HTTPServer):
+    with server:
+        server.serve_forever()
+
+
+def test_http_get_post():
+    server = HTTPServer(("localhost", 0), Handler)
+    thread = threading.Thread(target=run_server, args=(server,), daemon=True)
+    thread.start()
+    base_url = f"http://{server.server_address[0]}:{server.server_address[1]}"
+
+    ctx = build_ctx()
+    result_get = http_get(
+        Step(id="g", action="http.get", params={"url": base_url}), ctx
+    )
+    assert result_get == {"msg": "ok"}
+
+    result_post = http_post(
+        Step(id="p", action="http.post", params={"url": base_url, "data": {"a": 1}}),
+        ctx,
+    )
+    assert result_post == {"echo": {"a": 1}}
+
+    server.shutdown()
+    thread.join()

--- a/workflow/__init__.py
+++ b/workflow/__init__.py
@@ -5,6 +5,8 @@ from .runner import Runner
 from .scheduler import CronScheduler, capture_crash
 from .overlay import ControlOverlay
 from .actions_access import ACCESS_ACTIONS
+from .actions_http import HTTP_ACTIONS
+from .actions_files import FILES_ACTIONS
 
 __all__ = [
     "Flow",
@@ -14,4 +16,6 @@ __all__ = [
     "capture_crash",
     "ControlOverlay",
     "ACCESS_ACTIONS",
+    "HTTP_ACTIONS",
+    "FILES_ACTIONS",
 ]

--- a/workflow/actions.py
+++ b/workflow/actions.py
@@ -1620,12 +1620,16 @@ from .actions_office import OFFICE_ACTIONS
 from .actions_word import WORD_ACTIONS
 from .actions_outlook import OUTLOOK_ACTIONS
 from .actions_access import ACCESS_ACTIONS
+from .actions_http import HTTP_ACTIONS
+from .actions_files import FILES_ACTIONS
 
 BUILTIN_ACTIONS.update(WEB_ACTIONS)
 BUILTIN_ACTIONS.update(OFFICE_ACTIONS)
 BUILTIN_ACTIONS.update(WORD_ACTIONS)
 BUILTIN_ACTIONS.update(OUTLOOK_ACTIONS)
 BUILTIN_ACTIONS.update(ACCESS_ACTIONS)
+BUILTIN_ACTIONS.update(HTTP_ACTIONS)
+BUILTIN_ACTIONS.update(FILES_ACTIONS)
 
 BUILTIN_ACTIONS.update(
     {

--- a/workflow/actions_files.py
+++ b/workflow/actions_files.py
@@ -1,0 +1,62 @@
+"""File system actions for reading and writing files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+from typing import Any
+
+from .flow import Step
+from .runner import ExecutionContext
+
+
+def file_read(step: Step, ctx: ExecutionContext) -> Any:
+    path = Path(step.params["path"])
+    mode = step.params.get("mode", "text")
+    encoding = step.params.get("encoding", "utf-8")
+    if mode == "binary":
+        return path.read_bytes()
+    return path.read_text(encoding)
+
+
+def file_write(step: Step, ctx: ExecutionContext) -> Any:
+    path = Path(step.params["path"])
+    content = step.params.get("content", "")
+    mode = step.params.get("mode", "text")
+    encoding = step.params.get("encoding", "utf-8")
+    if mode == "binary":
+        data = content.encode(encoding) if isinstance(content, str) else content
+        path.write_bytes(data)
+    else:
+        data = content.decode(encoding) if isinstance(content, bytes) else content
+        path.write_text(data, encoding)
+    return str(path)
+
+
+def file_copy(step: Step, ctx: ExecutionContext) -> Any:
+    src = Path(step.params["src"])
+    dst = Path(step.params["dst"])
+    shutil.copyfile(src, dst)
+    return str(dst)
+
+
+def file_move(step: Step, ctx: ExecutionContext) -> Any:
+    src = Path(step.params["src"])
+    dst = Path(step.params["dst"])
+    shutil.move(src, dst)
+    return str(dst)
+
+
+def file_delete(step: Step, ctx: ExecutionContext) -> Any:
+    path = Path(step.params["path"])
+    path.unlink()
+    return str(path)
+
+
+FILES_ACTIONS = {
+    "file.read": file_read,
+    "file.write": file_write,
+    "file.copy": file_copy,
+    "file.move": file_move,
+    "file.delete": file_delete,
+}

--- a/workflow/actions_http.py
+++ b/workflow/actions_http.py
@@ -1,0 +1,56 @@
+"""HTTP actions using urllib."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+from urllib import parse, request
+
+from .flow import Step
+from .runner import ExecutionContext
+
+
+def http_get(step: Step, ctx: ExecutionContext) -> Any:
+    url = step.params["url"]
+    params: Dict[str, Any] | None = step.params.get("params")
+    headers: Dict[str, str] = step.params.get("headers") or {}
+    if params:
+        query = parse.urlencode(params)
+        sep = "&" if "?" in url else "?"
+        url = f"{url}{sep}{query}"
+    req = request.Request(url, headers=headers, method="GET")
+    with request.urlopen(req) as resp:
+        body = resp.read()
+        content_type = resp.headers.get("Content-Type", "")
+        if "application/json" in content_type:
+            return json.loads(body.decode())
+        return body.decode()
+
+
+def http_post(step: Step, ctx: ExecutionContext) -> Any:
+    url = step.params["url"]
+    data = step.params.get("data")
+    headers: Dict[str, str] = step.params.get("headers") or {}
+    body: bytes | None
+    if data is None:
+        body = None
+    elif isinstance(data, (dict, list)):
+        body = json.dumps(data).encode()
+        headers.setdefault("Content-Type", "application/json")
+    elif isinstance(data, str):
+        body = data.encode()
+    else:
+        body = data
+    req = request.Request(url, data=body, headers=headers, method="POST")
+    with request.urlopen(req) as resp:
+        body = resp.read()
+        content_type = resp.headers.get("Content-Type", "")
+        if "application/json" in content_type:
+            return json.loads(body.decode())
+        return body.decode()
+
+
+HTTP_ACTIONS = {
+    "http.get": http_get,
+    "http.post": http_post,
+}

--- a/workflow/runner.py
+++ b/workflow/runner.py
@@ -92,11 +92,11 @@ ACTION_PERMISSIONS: Dict[str, str] = {
     "http.get": "http",
     "http.post": "http",
     # File system actions
-    "file.read": "file",
-    "file.write": "file",
-    "file.copy": "file",
-    "file.move": "file",
-    "file.delete": "file",
+    "file.read": "files",
+    "file.write": "files",
+    "file.copy": "files",
+    "file.move": "files",
+    "file.delete": "files",
 }
 
 


### PR DESCRIPTION
## Summary
- add `http.get`/`http.post` actions and file system helpers for read/write/copy/move/delete
- register new actions and expose corresponding permissions
- test HTTP and file actions and updated permissions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897547138148327915b2e2725f841fa