### PR TITLE
Extend step logging with environment metadata

### DIFF
--- a/tests/test_logging_new_fields.py
+++ b/tests/test_logging_new_fields.py
@@ -1,0 +1,58 @@
+import json
+import socket
+import getpass
+
+from workflow.flow import Flow
+from workflow.runner import Runner
+from workflow.actions import BUILTIN_ACTIONS
+from workflow import scheduler
+
+
+def test_log_includes_environment_and_retry(tmp_path, monkeypatch):
+    monkeypatch.setattr(socket, "gethostname", lambda: "host1")
+    monkeypatch.setattr(getpass, "getuser", lambda: "user1")
+    monkeypatch.setattr(
+        scheduler,
+        "_get_display_info",
+        lambda: {"dpi": 123, "monitors": [{"width": 1, "height": 2}]},
+    )
+
+    flow_dict = {
+        "version": "1.0",
+        "meta": {"name": "wf"},
+        "steps": [
+            {
+                "id": "s1",
+                "action": "fail_once",
+                "selector": {"css": "btn"},
+                "retry": 1,
+            }
+        ],
+    }
+    flow = Flow.from_dict(flow_dict)
+
+    state = {"fail": True}
+
+    def fail_once(step, ctx):
+        if state["fail"]:
+            state["fail"] = False
+            raise ValueError("boom")
+        return "done"
+
+    runner = Runner(run_id="run1", base_dir=tmp_path)
+    for name, func in BUILTIN_ACTIONS.items():
+        runner.register_action(name, func)
+    runner.register_action("fail_once", fail_once)
+
+    runner.run_flow(flow, {})
+
+    log_file = runner.run_dir / "log.jsonl"
+    records = [json.loads(line) for line in log_file.read_text().splitlines()]
+    rec = records[-1]
+    assert rec["host"] == "host1"
+    assert rec["user"] == "user1"
+    assert rec["dpi"] == 123
+    assert rec["monitors"] == [{"width": 1, "height": 2}]
+    assert rec["selectorUsed"] == {"css": "btn"}
+    assert rec["retries"] == 1
+    assert rec["fallbackUsed"] is True

--- a/workflow/logging.py
+++ b/workflow/logging.py
@@ -13,6 +13,14 @@ def log_step(
     action: str,
     duration: float,
     result: str,
+    *,
+    host: Optional[str] = None,
+    user: Optional[str] = None,
+    dpi: Optional[int] = None,
+    monitors: Optional[Any] = None,
+    selectorUsed: Optional[Any] = None,
+    retries: Optional[int] = None,
+    fallbackUsed: Optional[bool] = None,
     redact: Optional[Iterable[str]] = None,
     **extra: Any,
 ) -> None:
@@ -32,6 +40,20 @@ def log_step(
         Duration of the step in milliseconds.
     result: str
         Result of the step (e.g. ``"ok"`` or ``"error"``).
+    host: str, optional
+        Hostname of the machine executing the step.
+    user: str, optional
+        User running the workflow.
+    dpi: int, optional
+        Screen DPI value.
+    monitors: list, optional
+        List of monitor geometries.
+    selectorUsed: any, optional
+        Selector that was ultimately used for the step.
+    retries: int, optional
+        Number of retry attempts before this execution.
+    fallbackUsed: bool, optional
+        Whether a fallback profile or selector was used.
     redact: Iterable[str], optional
         Names of fields whose values should be redacted in the log.
     extra: dict
@@ -45,8 +67,31 @@ def log_step(
         "duration": duration,
         "result": result,
     }
+    if host is not None:
+        record["host"] = host
+    if user is not None:
+        record["user"] = user
+    if dpi is not None:
+        record["dpi"] = dpi
+    if monitors is not None:
+        record["monitors"] = monitors
+    if selectorUsed is not None:
+        record["selectorUsed"] = selectorUsed
+    if retries is not None:
+        record["retries"] = retries
+    if fallbackUsed is not None:
+        record["fallbackUsed"] = fallbackUsed
     record.update(extra)
-    unmasked = {"runId", "stepId", "action", "screenshot", "uiTree", "webTrace"}
+    unmasked = {
+        "runId",
+        "stepId",
+        "action",
+        "screenshot",
+        "uiTree",
+        "webTrace",
+        "host",
+        "user",
+    }
     for k, v in list(record.items()):
         if k not in unmasked and isinstance(v, str):
             record[k] = mask_pii(v)


### PR DESCRIPTION
## Summary
- capture host, user, DPI, monitor info, selector used, retry count, and fallback flag in `log_step`
- collect environment and selector data in runner and forward to `log_step`
- verify new log fields via test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897570e5958832780256d02e3e52bf0