### PR TITLE
feat: add update rollback with version file

### DIFF
--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -6,32 +6,64 @@ from workflow.package_utils import sign_package
 from workflow.updater import apply_update
 
 
+def _make_package(tmp_path: Path, filename: str = "new.txt") -> Path:
+    pkg_dir = tmp_path / "pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / filename).write_text("new")
+    sign_package(pkg_dir, b"good")
+    return pkg_dir.with_suffix(".zip")
+
+
 def test_apply_update_invalid_signature_rolls_back(tmp_path: Path):
     # existing installation
     install = tmp_path / "app"
     install.mkdir()
     (install / "old.txt").write_text("old")
 
-    # version information
-    version_file = tmp_path / "version.txt"
-    version_file.write_text("2.0")
+    # remote version info
+    remote_version = tmp_path / "remote_version.txt"
+    remote_version.write_text("2.0")
 
-    # new package with valid signature
-    pkg_dir = tmp_path / "pkg"
-    pkg_dir.mkdir()
-    (pkg_dir / "new.txt").write_text("new")
-    good_key = b"good"
-    sign_package(pkg_dir, good_key)
-    pkg_zip = pkg_dir.with_suffix(".zip")
+    # local version file
+    version_file = tmp_path / "current_version.txt"
+    version_file.write_text("1.0")
+
+    pkg_zip = _make_package(tmp_path)
 
     with pytest.raises(ValueError):
         apply_update(
-            version_file.as_uri(),
+            remote_version.as_uri(),
             pkg_zip.as_uri(),
             install,
-            current_version="1.0",
+            version_file,
             key=b"bad",  # wrong key triggers verification failure
         )
 
     assert (install / "old.txt").read_text() == "old"
     assert not (install / "new.txt").exists()
+    assert version_file.read_text() == "1.0"
+
+
+def test_apply_update_failure_restores_version_file(tmp_path: Path):
+    install = tmp_path / "app"
+    install.mkdir()
+    (install / "old.txt").write_text("old")
+
+    remote_version = tmp_path / "remote_version.txt"
+    remote_version.write_text("2.0")
+
+    version_file = tmp_path / "current_version.txt"
+    version_file.write_text("1.0")
+
+    pkg_zip = _make_package(tmp_path)
+
+    with pytest.raises(ValueError):
+        apply_update(
+            remote_version.as_uri(),
+            pkg_zip.as_uri(),
+            install,
+            version_file,
+            key=b"bad",
+        )
+
+    assert version_file.read_text() == "1.0"

--- a/workflow/updater.py
+++ b/workflow/updater.py
@@ -23,26 +23,50 @@ def apply_update(
     version_url: str,
     package_url: str,
     install_dir: PathLike,
-    current_version: str,
+    version_file: PathLike,
     key: bytes,
 ) -> bool:
     """Check for an update and apply it if available.
 
+    Parameters
+    ----------
+    version_url:
+        URL returning the latest available version string.
+    package_url:
+        URL to the signed ZIP package for the latest version.
+    install_dir:
+        Directory where the package should be installed.
+    version_file:
+        Path to a file containing the currently installed version.  The file is
+        updated on success and restored on failure which allows the version to
+        be pinned between executions.
+    key:
+        Public key used to verify the package signature.
+
     The function fetches the latest version from ``version_url``.  When the
-    version differs from ``current_version`` a signed ZIP package is downloaded
-    from ``package_url`` and verified using ``key``.  The current installation
-    is backed up before applying the update and restored if verification fails.
+    version differs from the one stored in ``version_file`` a signed ZIP
+    package is downloaded from ``package_url`` and verified using ``key``.  The
+    current installation and version file are backed up before applying the
+    update and restored if verification fails or any error occurs.
     """
+    version_path = Path(version_file)
+    current_version = (
+        version_path.read_text().strip() if version_path.exists() else ""
+    )
     latest = check_version(version_url)
     if latest == current_version:
         return False
 
     dest = Path(install_dir)
     backup = dest.with_suffix(dest.suffix + ".bak")
+    version_backup = version_path.with_suffix(version_path.suffix + ".bak")
+
     if backup.exists():
         shutil.rmtree(backup)
     if dest.exists():
         dest.rename(backup)
+    if version_path.exists():
+        shutil.copy2(version_path, version_backup)
 
     try:
         with tempfile.TemporaryDirectory() as tmp:
@@ -59,15 +83,22 @@ def apply_update(
                 zf.extractall(extract_dir)
             dest.parent.mkdir(parents=True, exist_ok=True)
             shutil.copytree(extract_dir, dest)
+            version_path.write_text(latest)
     except Exception:
         if backup.exists():
             if dest.exists():
                 shutil.rmtree(dest)
             backup.rename(dest)
+        if version_backup.exists():
+            if version_path.exists():
+                version_path.unlink()
+            version_backup.rename(version_path)
         raise
     else:
         if backup.exists():
             shutil.rmtree(backup)
+        if version_backup.exists():
+            version_backup.unlink()
     return True
 
 


### PR DESCRIPTION
## Summary
- persist installed version in a file and restore on update failure
- allow pinning version through configuration file
- test automatic rollback when update verification fails

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt6')*
- `pip install PyQt6 -q` *(fails: Could not find a version that satisfies the requirement PyQt6)*
- `pytest tests/test_updater.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68976215b0588327803b13d2b44350b9