### PR TITLE
Add Excel activate and close actions

### DIFF
--- a/tests/test_actions_office.py
+++ b/tests/test_actions_office.py
@@ -53,3 +53,20 @@ def test_excel_actions(monkeypatch):
         ctx,
     )
     cells.Replace.assert_called_once_with("old", "new")
+
+    wb2 = MagicMock()
+    app.Workbooks.return_value = wb2
+    office.excel_activate(
+        Step(id="act", action="excel.activate", params={"name": "Book2"}), ctx
+    )
+    app.Workbooks.assert_called_once_with("Book2")
+    wb2.Activate.assert_called_once()
+    assert ctx.globals["_excel_book"] is wb2
+
+    office.excel_close(
+        Step(id="close", action="excel.close", params={"save": False}), ctx
+    )
+    wb2.Close.assert_called_once_with(SaveChanges=False)
+    app.Quit.assert_called_once()
+    assert "_excel_book" not in ctx.globals
+    assert "_excel_app" not in ctx.globals

--- a/workflow/actions_office.py
+++ b/workflow/actions_office.py
@@ -92,6 +92,28 @@ def excel_find_replace(step: Step, ctx: ExecutionContext) -> Any:
     return replace
 
 
+def excel_close(step: Step, ctx: ExecutionContext) -> Any:
+    """Close the active workbook and quit the Excel application."""
+    save = step.params.get("save", False)
+    wb = ctx.globals.pop(_EXCEL_BOOK, None)
+    if wb is not None:
+        wb.Close(SaveChanges=save)
+    app = ctx.globals.pop(_EXCEL_APP, None)
+    if app is not None:
+        app.Quit()
+    return True
+
+
+def excel_activate(step: Step, ctx: ExecutionContext) -> Any:
+    """Activate an open workbook by name."""
+    name = step.params["name"]
+    app = ctx.globals[_EXCEL_APP]
+    wb = app.Workbooks(name)
+    wb.Activate()
+    ctx.globals[_EXCEL_BOOK] = wb
+    return name
+
+
 OFFICE_ACTIONS = {
     "excel.open": excel_open,
     "excel.get": excel_get,
@@ -100,4 +122,6 @@ OFFICE_ACTIONS = {
     "excel.run_macro": excel_run_macro,
     "excel.export": excel_export,
     "excel.find_replace": excel_find_replace,
+    "excel.close": excel_close,
+    "excel.activate": excel_activate,
 }

--- a/workflow/runner.py
+++ b/workflow/runner.py
@@ -82,6 +82,8 @@ ACTION_PERMISSIONS: Dict[str, str] = {
     "excel.run_macro": "office",
     "excel.export": "office",
     "excel.find_replace": "office",
+    "excel.close": "office",
+    "excel.activate": "office",
     "word.open": "office",
     "word.save": "office",
     "word.run_macro": "office",


### PR DESCRIPTION
## Summary
- add `excel_activate` to switch active workbook
- add `excel_close` to close workbooks and quit Excel
- cover new actions with unit tests

## Testing
- `pytest tests/test_actions_office.py tests/test_action_permissions.py`
- `pip install PyQt6` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68976611ff848327b0ca7856006c5056