### PR TITLE
Add tab and alt selector recovery actions

### DIFF
--- a/workflow/actions.py
+++ b/workflow/actions.py
@@ -1571,6 +1571,26 @@ def switch_layout(step: Step, ctx: ExecutionContext) -> Any:
     return layout
 
 
+def tab_switch(step: Step, ctx: ExecutionContext) -> Any:
+    """Switch to the next tab using the ``Ctrl+Tab`` hotkey."""
+
+    _send_hotkey("ctrl", "tab")
+    return True
+
+
+def alt_selector(step: Step, ctx: ExecutionContext) -> Any:
+    """Replace the selector of another step with an alternative."""
+
+    target_step = step.params.get("step")
+    new_selector = step.params.get("selector")
+    if not isinstance(target_step, Step):
+        raise ValueError("alt_selector requires 'step'")
+    if not isinstance(new_selector, dict):
+        raise ValueError("alt_selector requires 'selector'")
+    target_step.selector = new_selector
+    return new_selector
+
+
 def _stub_action(step: Step, ctx: ExecutionContext) -> Any:
     """Placeholder for unimplemented UI actions.
 
@@ -1688,5 +1708,7 @@ BUILTIN_ACTIONS.update(
         "ime.on": ime_on,
         "ime.off": ime_off,
         "layout.switch": switch_layout,
+        "tab_switch": tab_switch,
+        "alt_selector": alt_selector,
     }
 )

--- a/workflow/runner.py
+++ b/workflow/runner.py
@@ -841,9 +841,27 @@ class Runner:
                 "params": {"clicks": -1},
             }
 
+        def _tab(s: Step) -> Dict[str, Any]:
+            return {
+                "id": f"{s.id}#tab",
+                "action": "tab_switch",
+            }
+
+        def _alt_selector(s: Step) -> Dict[str, Any]:
+            alt = s.onError.get("altSelector")
+            if not isinstance(alt, dict):
+                raise ValueError("onError.altSelector required for 'alt_selector'")
+            return {
+                "id": f"{s.id}#alt_selector",
+                "action": "alt_selector",
+                "params": {"step": s, "selector": alt},
+            }
+
         shorthand: Dict[str, Callable[[Step], Dict[str, Any]]] = {
             "re-activate": _reactivate,
             "scroll": _scroll,
+            "tab": _tab,
+            "alt_selector": _alt_selector,
         }
 
         steps_data: List[Any]


### PR DESCRIPTION
## Summary
- add `tab_switch` action to emit Ctrl+Tab and `alt_selector` to swap selectors
- support `tab` and `alt_selector` shorthand recovery steps
- test that new recover shorthands trigger tab switch and alternate selectors

## Testing
- `pytest tests/test_on_error.py::test_recover_scroll_retry_success tests/test_on_error.py::test_recover_tab_retry_success tests/test_on_error.py::test_recover_alt_selector_retry_success -q`

------
https://chatgpt.com/codex/tasks/task_e_68976827d94c8327b5f8d64955166182