### PR TITLE
feat: add pattern option for web downloads

### DIFF
--- a/tests/test_actions_web.py
+++ b/tests/test_actions_web.py
@@ -139,6 +139,20 @@ def test_download_verification(tmp_path):
         Step(id="dl2", action="download", params={"selector": "dl", "path": str(dest)}), ctx
     )
     assert dest.exists() and dest.read_text() == "hello"
+
+    # With directory and pattern
+    dest_dir = tmp_path / "dir"
+    dest_dir.mkdir()
+    found = web_download(
+        Step(
+            id="dl3",
+            action="download",
+            params={"selector": "dl", "path": str(dest_dir), "pattern": "*.txt"},
+        ),
+        ctx,
+    )
+    found_path = Path(found)
+    assert found_path.parent == dest_dir and found_path.read_text() == "hello"
     ctx.globals["_browser"].close()
     ctx.globals["_playwright"].stop()
 


### PR DESCRIPTION
## Summary
- extend web download action with optional `pattern` argument to wait for files matching a glob in a directory and ensure size stability
- add tests for pattern-based downloads

## Testing
- `pytest tests/test_actions_web.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt6')*


------
https://chatgpt.com/codex/tasks/task_e_6897763994c48327a9e06abaea0e51fb