### PR TITLE
Add basic orchestration layer and dashboard

### DIFF
--- a/workflow/__init__.py
+++ b/workflow/__init__.py
@@ -3,6 +3,7 @@
 from .flow import Flow, Step
 from .runner import Runner
 from .scheduler import CronScheduler, capture_crash
+from .orchestrator import Orchestrator, orchestrator
 from .overlay import ControlOverlay
 from .actions_access import ACCESS_ACTIONS
 from .actions_http import HTTP_ACTIONS
@@ -15,6 +16,8 @@ __all__ = [
     "Runner",
     "CronScheduler",
     "capture_crash",
+    "Orchestrator",
+    "orchestrator",
     "ControlOverlay",
     "ACCESS_ACTIONS",
     "HTTP_ACTIONS",

--- a/workflow/orchestrator.py
+++ b/workflow/orchestrator.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+"""Simple in-memory orchestration layer for dispatching jobs to multiple
+hosts.
+
+This module provides a minimal orchestration engine that can be used by the
+scheduler and runner to coordinate job execution across a fleet of hosts.  It
+is intentionally lightweight and does not persist state; callers are expected
+to keep the process alive for the lifetime of the orchestration session.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from threading import Lock
+from typing import Dict, Optional, List
+import uuid
+
+
+@dataclass
+class Job:
+    """Represents a single scheduled job."""
+
+    flow: str
+    id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    host: Optional[str] = None
+    status: str = "queued"  # queued -> running -> finished/failed/stopped
+    started: Optional[datetime] = None
+    finished: Optional[datetime] = None
+    result: Optional[str] = None
+
+
+class Orchestrator:
+    """In-memory orchestration engine.
+
+    The orchestrator keeps track of submitted jobs and their execution state
+    across multiple hosts.  Each host polls for work using :meth:`assign_job`
+    and reports progress back via :meth:`update_status`.
+    """
+
+    def __init__(self) -> None:
+        self.jobs: Dict[str, Job] = {}
+        self.lock = Lock()
+
+    # ------------------------------------------------------------------
+    # Job submission and assignment
+    # ------------------------------------------------------------------
+    def submit(self, flow: str) -> Job:
+        """Create a new job for the given flow and return it."""
+        job = Job(flow=flow)
+        with self.lock:
+            self.jobs[job.id] = job
+        return job
+
+    def assign_job(self, host: str) -> Optional[Job]:
+        """Assign the next queued job to ``host`` and mark it running.
+
+        Returns the job or ``None`` if no work is available.
+        """
+        with self.lock:
+            for job in self.jobs.values():
+                if job.status == "queued":
+                    job.status = "running"
+                    job.host = host
+                    job.started = datetime.utcnow()
+                    return job
+        return None
+
+    # ------------------------------------------------------------------
+    # Status updates
+    # ------------------------------------------------------------------
+    def update_status(
+        self, job_id: str, status: str, *, result: Optional[str] = None
+    ) -> None:
+        """Update status for ``job_id``.
+
+        ``status`` should be one of ``running``, ``finished``, ``failed`` or
+        ``stopped``.
+        """
+        with self.lock:
+            job = self.jobs.get(job_id)
+            if not job:
+                return
+            job.status = status
+            if status in {"finished", "failed", "stopped"}:
+                job.finished = datetime.utcnow()
+                job.result = result
+
+    # ------------------------------------------------------------------
+    # Control operations
+    # ------------------------------------------------------------------
+    def stop(self, job_id: str) -> None:
+        """Mark ``job_id`` as stopped."""
+        self.update_status(job_id, "stopped")
+
+    def rerun(self, job_id: str) -> Optional[Job]:
+        """Requeue the given job with a new identifier."""
+        with self.lock:
+            old = self.jobs.get(job_id)
+            if not old:
+                return None
+            job = Job(flow=old.flow)
+            self.jobs[job.id] = job
+            return job
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+    def get_state(self) -> Dict[str, Dict[str, str]]:
+        """Return a serialisable snapshot of all jobs."""
+        with self.lock:
+            return {
+                jid: {
+                    "flow": j.flow,
+                    "host": j.host or "",
+                    "status": j.status,
+                    "started": j.started.isoformat() if j.started else "",
+                    "finished": j.finished.isoformat() if j.finished else "",
+                    "result": j.result or "",
+                }
+                for jid, j in self.jobs.items()
+            }
+
+
+# A module level orchestrator instance can be imported elsewhere
+orchestrator = Orchestrator()

--- a/workflow/orchestrator_api.py
+++ b/workflow/orchestrator_api.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+"""HTTP API for interacting with the orchestrator."""
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import HTMLResponse
+from pydantic import BaseModel
+
+from .orchestrator import orchestrator, Job
+
+app = FastAPI(title="RPA Orchestrator")
+
+
+class SubmitRequest(BaseModel):
+    flow: str
+
+
+class StatusUpdate(BaseModel):
+    status: str
+    result: str | None = None
+
+
+@app.post("/jobs")
+def submit_job(req: SubmitRequest) -> dict:
+    job = orchestrator.submit(req.flow)
+    return {"id": job.id}
+
+
+@app.get("/jobs/assign/{host}")
+def assign_job(host: str) -> dict:
+    job = orchestrator.assign_job(host)
+    if not job:
+        return {"id": None}
+    return {"id": job.id, "flow": job.flow}
+
+
+@app.post("/jobs/{job_id}/status")
+def update_status(job_id: str, upd: StatusUpdate) -> dict:
+    if job_id not in orchestrator.jobs:
+        raise HTTPException(status_code=404, detail="job not found")
+    orchestrator.update_status(job_id, upd.status, result=upd.result)
+    return {"ok": True}
+
+
+@app.post("/jobs/{job_id}/stop")
+def stop_job(job_id: str) -> dict:
+    orchestrator.stop(job_id)
+    return {"ok": True}
+
+
+@app.post("/jobs/{job_id}/rerun")
+def rerun_job(job_id: str) -> dict:
+    job = orchestrator.rerun(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="job not found")
+    return {"id": job.id}
+
+
+@app.get("/state")
+def state() -> dict:
+    return orchestrator.get_state()
+
+
+@app.get("/", response_class=HTMLResponse)
+def dashboard() -> str:
+    """Simple HTML dashboard showing job and queue status."""
+    rows = []
+    for jid, info in orchestrator.get_state().items():
+        rows.append(
+            f"<tr><td>{jid}</td><td>{info['flow']}</td><td>{info['host']}</td>"
+            f"<td>{info['status']}</td><td>{info['started']}</td>"
+            f"<td>{info['finished']}</td><td>{info['result']}</td></tr>"
+        )
+    table = "".join(rows) or "<tr><td colspan='7'>No jobs</td></tr>"
+    return (
+        "<html><head><title>Orchestrator</title></head><body><h1>Job Status"  # noqa: E501
+        "</h1><table border='1'><tr><th>ID</th><th>Flow</th><th>Host"  # noqa: E501
+        "</th><th>Status</th><th>Started</th><th>Finished</th>"  # noqa: E501
+        "<th>Result</th></tr>" + table + "</table></body></html>"
+    )


### PR DESCRIPTION
## Summary
- introduce in-memory orchestrator for multi-host job dispatch
- expose HTTP API with job control endpoints and simple HTML dashboard
- export orchestrator from workflow package for reuse

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'PyQt6')*


------
https://chatgpt.com/codex/tasks/task_e_6897e03312248327801a56967fd86bf1