### PR TITLE
Add table wizard for simplified table row selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,21 @@ s.add_job(
 }
 ```
 
+## テーブルウィザード
+
+`table.wizard` は列ヘッダ名やインデックスから検索条件を組み立て、
+内部で `table.find_row` と `row.select` を実行するアクションです。
+例えば次のように記述すると `name` 列が `Alice` の行を選択できます。
+
+```json
+{
+  "id": "find",
+  "action": "table.wizard",
+  "selector": {"mock": {}},
+  "params": {"query": "name=Alice", "select": true},
+  "out": "row"
+}
+```
+
+上記例では検索結果の行オブジェクトが `row` 変数に格納されます。
+

--- a/tests/flows/table_wizard_flow.json
+++ b/tests/flows/table_wizard_flow.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.0",
+  "meta": {"name": "table-wizard", "permissions": ["desktop.uia"]},
+  "steps": [
+    {
+      "id": "find",
+      "action": "table.wizard",
+      "selector": {"mock": {}},
+      "params": {"query": "name=Alice", "select": true},
+      "out": "found"
+    }
+  ]
+}

--- a/tests/test_actions_ui.py
+++ b/tests/test_actions_ui.py
@@ -145,6 +145,52 @@ def test_find_table_row(monkeypatch):
     assert row["dept"] == "IT"
 
 
+def test_table_wizard(monkeypatch):
+    class Row(dict):
+        def __init__(self, data):
+            super().__init__(data)
+            self.selected = False
+
+        def select(self):
+            self.selected = True
+
+    class Table:
+        headers = ["id", "name", "dept"]
+
+        def __init__(self):
+            self.rows = [
+                Row({"id": "1", "name": "Bob", "dept": "IT"}),
+                Row({"id": "2", "name": "Alice", "dept": "HR"}),
+            ]
+
+    table = Table()
+    monkeypatch.setattr(actions, "resolve_selector", lambda s: {"strategy": "mock", "target": table})
+    ctx = build_ctx()
+
+    row = actions.table_wizard(
+        Step(id="w1", action="table.wizard", selector={"mock": {}}, params={"query": "name=Bob"}),
+        ctx,
+    )
+    assert row["id"] == "1"
+
+    row = actions.table_wizard(
+        Step(id="w2", action="table.wizard", selector={"mock": {}}, params={"query": "1=Alice"}),
+        ctx,
+    )
+    assert row["name"] == "Alice"
+
+    row = actions.table_wizard(
+        Step(
+            id="w3",
+            action="table.wizard",
+            selector={"mock": {}},
+            params={"query": "dept=IT", "select": True},
+        ),
+        ctx,
+    )
+    assert row.selected
+
+
 def test_cell_get_set_from_row():
     ctx = build_ctx()
     row = {"id": "1", "name": "Bob"}

--- a/workflow/runner.py
+++ b/workflow/runner.py
@@ -58,6 +58,7 @@ ACTION_PERMISSIONS: Dict[str, str] = {
     "wait_image_disappear": "desktop.image",
     "ocr_read": "desktop.image",
     "click_xy": "desktop.uia",
+    "table.wizard": "desktop.uia",
     "table.find_row": "desktop.uia",
     "row.select": "desktop.uia",
     "row.double_click": "desktop.uia",


### PR DESCRIPTION
## Summary
- implement `table.wizard` that parses simple column queries and delegates to `table.find_row`
- register action and permission for UI usage
- document and test `table.wizard` with sample flow

## Testing
- `pytest tests/test_actions_ui.py::test_table_wizard tests/test_regression_flows.py::test_table_wizard_flow -q`

------
https://chatgpt.com/codex/tasks/task_e_6897e7949b7083279fc8f539f10b799f