### PR TITLE
feat: expose workflow run statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@
 python rpa_main_ui.py
 ```
 
+## ダッシュボード
+
+FastAPI ベースのオーケストレータ API を起動すると、ブラウザからジョブの状態や実行統計を確認できます。
+
+```bash
+uvicorn workflow.orchestrator_api:app --reload
+```
+
+起動後は [http://localhost:8000/](http://localhost:8000/) にアクセスするとジョブ一覧が表示されます。`/stats` エンドポイントでは以下の情報を確認できます。デフォルトは JSON 形式で、`?format=html` を付けると HTML でも表示できます。
+
+- 全体の成功率と平均実行時間
+- 失敗理由の集計
+- セレクタの成功率
+- 日/週/月ごとの集計
+- フロー別集計
+
 ## ロックファイル
 
 ワークフロー実行中は `runs/runner.lock` というファイルに排他ロックを取得し、

--- a/tests/test_orchestrator_api.py
+++ b/tests/test_orchestrator_api.py
@@ -1,0 +1,21 @@
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient  # type: ignore
+from workflow.orchestrator_api import app  # type: ignore
+from workflow.log_db import init_db, log_run
+
+
+def test_stats_endpoint(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    conn = init_db('runs.sqlite')
+    log_run(conn, '1', 'flow', 0.0, 1.0, True, selector_hit_rate=1.0)
+    client = TestClient(app)
+    resp = client.get('/stats')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['by_flow']['flow']['run_count'] == 1
+    resp_html = client.get('/stats?format=html')
+    assert resp_html.status_code == 200
+    assert '<html>' in resp_html.text.lower()


### PR DESCRIPTION
## Summary
- add aggregation helpers for per-period and per-flow run statistics
- expose `/stats` endpoint returning run metrics in JSON or HTML
- document dashboard and metrics in README

## Testing
- `pytest tests/test_log_db.py tests/test_orchestrator_api.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'PyQt6', No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_6897e91ee7fc832791adb1f1df6f4b0f