### PR TITLE
Handle flow execution and logging in on_run

### DIFF
--- a/rpa_main_ui.py
+++ b/rpa_main_ui.py
@@ -383,7 +383,26 @@ class MainWindow(QMainWindow):
         self.add_step(action=item.text().strip())
 
     def on_run(self):
-        self.log_panel.add_row(datetime.now().strftime("%H:%M:%S"), "Run", "Started", True)
+        """Execute the current flow and log the result."""
+        self.log_panel.add_row(
+            datetime.now().strftime("%H:%M:%S"), "Run", "Started", True
+        )
+        try:
+            data = json.loads(self.current_flow_path.read_text())
+            flow = Flow.from_dict(data)
+            runner = Runner()
+            runner.run_flow(flow)
+        except Exception as exc:  # pragma: no cover - defensive
+            self.log_panel.add_row(
+                datetime.now().strftime("%H:%M:%S"),
+                "Run",
+                f"Failed: {exc}",
+                False,
+            )
+        else:
+            self.log_panel.add_row(
+                datetime.now().strftime("%H:%M:%S"), "Run", "Finished", True
+            )
 
     def on_stop(self):
         self.log_panel.add_row(datetime.now().strftime("%H:%M:%S"), "Run", "Stopped", False)


### PR DESCRIPTION
## Summary
- Load current flow JSON and convert to Flow object in `MainWindow.on_run`
- Execute the flow with `Runner.run_flow` and log success or failure

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_6897f2ff64b08327ae435870a80f0d86