### PR TITLE
Add runner stop handling to MainWindow

### DIFF
--- a/tests/test_mainwindow_stop.py
+++ b/tests/test_mainwindow_stop.py
@@ -1,0 +1,27 @@
+import pytest
+
+pytest.importorskip("PyQt6")
+from PyQt6.QtWidgets import QApplication
+
+import rpa_main_ui
+
+
+class DummyRunner:
+    def __init__(self) -> None:
+        self.stopped = False
+
+    def stop(self) -> None:  # pragma: no cover - simple flag setter
+        self.stopped = True
+
+
+def test_on_stop_requests_runner_and_logs():
+    app = QApplication([])
+    window = rpa_main_ui.MainWindow()
+    dummy = DummyRunner()
+    window.runner = dummy
+    window.on_stop()
+    assert dummy.stopped
+    row = window.log_panel.table.rowCount() - 1
+    assert window.log_panel.table.item(row, 2).text().endswith("Stop requested")
+    window.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- retain Runner instance on MainWindow to enable stopping
- log stop requests in LogPanel
- add regression test for stopping

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_6897f49a9e688327abb75fda35fc29b9