### PR TITLE
Add dry-run flow execution to UI

### DIFF
--- a/rpa_main_ui.py
+++ b/rpa_main_ui.py
@@ -419,7 +419,27 @@ class MainWindow(QMainWindow):
             self.log_panel.add_row(now, "Run", "Stop requested", True)
 
     def on_dry(self):
-        self.log_panel.add_row(datetime.now().strftime("%H:%M:%S"), "Dry Run", "Started", True)
+        now = datetime.now().strftime("%H:%M:%S")
+        self.log_panel.add_row(now, "Dry Run", "Started", True)
+        try:
+            data = json.loads(self.current_flow_path.read_text())
+            flow = Flow.from_dict(data)
+            self.runner = Runner()
+            result = self.runner.run_flow(flow, auto_resume=True)
+        except Exception as exc:  # pragma: no cover - defensive
+            self.log_panel.add_row(
+                datetime.now().strftime("%H:%M:%S"),
+                "Dry Run",
+                f"Failed: {exc}",
+                False,
+            )
+        else:
+            self.log_panel.add_row(
+                datetime.now().strftime("%H:%M:%S"),
+                "Dry Run",
+                f"Finished: {json.dumps(result)}",
+                True,
+            )
 
     def on_setting(self):
         self.log_panel.add_row(datetime.now().strftime("%H:%M:%S"), "Setting", "Opened", True)

--- a/tests/test_mainwindow_dry_run.py
+++ b/tests/test_mainwindow_dry_run.py
@@ -1,0 +1,32 @@
+import pytest
+
+pytest.importorskip("PyQt6")
+from PyQt6.QtWidgets import QApplication
+
+import rpa_main_ui
+
+
+class DummyRunner:
+    def __init__(self) -> None:
+        self.kwargs = None
+
+    def run_flow(self, flow, inputs=None, path=None, *, auto_resume=False):  # pragma: no cover - simple stub
+        self.kwargs = {
+            "inputs": inputs,
+            "path": path,
+            "auto_resume": auto_resume,
+        }
+        return {"result": 123}
+
+
+def test_on_dry_runs_flow_with_auto_resume_and_logs(monkeypatch):
+    app = QApplication([])
+    dummy = DummyRunner()
+    monkeypatch.setattr(rpa_main_ui, "Runner", lambda: dummy)
+    window = rpa_main_ui.MainWindow()
+    window.on_dry()
+    assert dummy.kwargs["auto_resume"]
+    row = window.log_panel.table.rowCount() - 1
+    assert window.log_panel.table.item(row, 2).text().endswith('Finished: {"result": 123}')
+    window.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- support dry-run execution in MainWindow by loading the flow and passing auto_resume to Runner
- add test verifying dry-run uses auto_resume and logs result

## Testing
- `pytest` *(fails: No module named 'PyQt6')*
- `pip install PyQt6` *(fails: Could not find a version that satisfies the requirement PyQt6)*
- `pytest tests/test_mainwindow_dry_run.py tests/test_mainwindow_stop.py -q` *(skipped: PyQt6)*


------
https://chatgpt.com/codex/tasks/task_e_6897f9fe6a588327bb089bba8dd245e9