### PR TITLE
Add log step callbacks and UI integration

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,5 +1,5 @@
 import json
-from workflow.logging import log_step
+from workflow.logging import log_step, set_step_log_callback
 
 
 def test_log_step_redact(tmp_path):
@@ -7,3 +7,15 @@ def test_log_step_redact(tmp_path):
     content = (tmp_path / "log.jsonl").read_text().splitlines()[0]
     record = json.loads(content)
     assert record["output"] == "***"
+
+
+def test_log_step_callback(tmp_path):
+    got = []
+
+    def cb(rec: dict) -> None:
+        got.append(rec)
+
+    set_step_log_callback(cb)
+    log_step("r1", tmp_path, "s1", "click", 1.0, "ok")
+    assert got and got[0]["stepId"] == "s1"
+    set_step_log_callback(None)


### PR DESCRIPTION
## Summary
- add optional callback registration in workflow logging
- bridge step log records to UI log panel via Qt signal
- test that log_step invokes registered callback

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'PyQt6')*


------
https://chatgpt.com/codex/tasks/task_e_6897fbf346548327980f4e5c621295b8