### PR TITLE
Add selector editor dialog and integrate with properties panel

### DIFF
--- a/rpa_main_ui.py
+++ b/rpa_main_ui.py
@@ -52,6 +52,7 @@ from workflow.runner import Runner
 from workflow.logging import set_step_log_callback
 from workflow.actions import list_actions
 from settings_dialog import SettingsDialog
+from selector_editor_dialog import SelectorEditorDialog
 
 # Global queue receiving actions recorded by external modules
 recorded_actions_q: "queue.Queue[dict]" = queue.Queue()
@@ -338,7 +339,9 @@ class PropertiesPanel(QWidget):
         self.chk = QCheckBox("Save screenshot")
         self.chk.setChecked(True)
         form.addRow("Action", self.act)
-        form.addRow("Seekitor Editor", QPushButton("開く…"))
+        self.selector_btn = QPushButton("開く…")
+        self.selector_btn.clicked.connect(self._open_selector_editor)
+        form.addRow("Seekitor Editor", self.selector_btn)
         form.addRow(self.selector)
         v.addLayout(form)
 
@@ -367,6 +370,13 @@ class PropertiesPanel(QWidget):
         self.to.valueChanged.connect(self._on_changed)
         self.re.valueChanged.connect(self._on_changed)
         self.chk.toggled.connect(self._on_changed)
+
+    def _open_selector_editor(self) -> None:
+        """Open a dialog for editing the selector value."""
+        dlg = SelectorEditorDialog(self.selector.text(), self)
+        if dlg.exec():
+            self.selector.setText(dlg.selector)
+            self._on_changed()
 
     def set_advanced_visible(self, visible: bool) -> None:
         self.advanced_group.setVisible(visible)

--- a/selector_editor_dialog.py
+++ b/selector_editor_dialog.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from PyQt6.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLineEdit,
+    QPushButton,
+    QWidget,
+)
+
+
+class SelectorEditorDialog(QDialog):
+    """Simple dialog for editing a selector string."""
+
+    def __init__(self, value: str = "", parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Selector Editor")
+        layout = QVBoxLayout(self)
+
+        self._edit = QLineEdit(value)
+        layout.addWidget(self._edit)
+
+        btns = QHBoxLayout()
+        ok_btn = QPushButton("OK")
+        cancel_btn = QPushButton("Cancel")
+        ok_btn.clicked.connect(self.accept)
+        cancel_btn.clicked.connect(self.reject)
+        btns.addWidget(ok_btn)
+        btns.addWidget(cancel_btn)
+        layout.addLayout(btns)
+
+    @property
+    def selector(self) -> str:
+        """Return the edited selector string."""
+        return self._edit.text().strip()


### PR DESCRIPTION
## Summary
- add `SelectorEditorDialog` for editing step selectors
- wire property panel button to open selector editor and apply changes

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'PyQt6')*


------
https://chatgpt.com/codex/tasks/task_e_68984c4b87dc83279e5eb1dc41538f0a