### PR TITLE
Use lambda for add-step button

### DIFF
--- a/rpa_main_ui.py
+++ b/rpa_main_ui.py
@@ -811,7 +811,9 @@ class MainWindow(QMainWindow):
         center_scroll = QScrollArea(); center_scroll.setWidgetResizable(True)
         self.canvas = DottedCanvas()
         self.add_btn = add_step_button()
-        self.add_btn.clicked.connect(self.add_step)
+        # When clicked, QPushButton emits a boolean 'checked' state. Use a lambda
+        # to discard this parameter so add_step receives no unintended arguments.
+        self.add_btn.clicked.connect(lambda: self.add_step())
         self.canvas.v.addWidget(self.add_btn)
         self.step_count = 0
         self.canvas.list.orderChanged.connect(self._sync_flow_order)

--- a/tests/test_add_step_button.py
+++ b/tests/test_add_step_button.py
@@ -1,0 +1,15 @@
+import pytest
+
+pytest.importorskip("PyQt6")
+from PyQt6.QtWidgets import QApplication
+import rpa_main_ui
+
+
+def test_add_step_button(monkeypatch, tmp_path):
+    monkeypatch.setattr(rpa_main_ui.Path, "home", lambda: tmp_path)
+    app = QApplication([])
+    window = rpa_main_ui.MainWindow()
+    window.add_btn.click()
+    assert len(window.flow.steps) > 0
+    window.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- Prevent QPushButton `clicked` signal from passing its boolean parameter into `add_step`
- Add regression test to ensure clicking the add-step button inserts a step

## Testing
- `pytest tests/test_add_step_button.py -q` *(fails: 1 skipped because PyQt6 is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68987512d2a4832783914220660f0325