### PR TITLE
Add element manager dialog and tests

### DIFF
--- a/element_manager_dialog.py
+++ b/element_manager_dialog.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from PyQt6.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLineEdit,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QWidget,
+    QLabel,
+)
+
+from workflow.gui_tools import element_spy
+
+
+TEXT = {
+    "title": "要素取得・管理",
+    "desc": "セレクタを指定して要素情報を取得し、一覧で管理します。",
+    "selector_placeholder": "#main > div",
+    "spy": "取得",
+    "remove": "削除",
+    "close": "閉じる",
+    "column_selector": "セレクタ",
+    "column_name": "Name",
+    "column_auto": "AutomationId",
+    "column_type": "ControlType",
+    "column_class": "ClassName",
+}
+
+
+class ElementManagerDialog(QDialog):
+    """Simple dialog to capture and list element information."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle(TEXT["title"])
+        layout = QVBoxLayout(self)
+
+        layout.addWidget(QLabel(TEXT["desc"]))
+
+        form = QHBoxLayout()
+        self.selector_edit = QLineEdit()
+        self.selector_edit.setPlaceholderText(TEXT["selector_placeholder"])
+        form.addWidget(self.selector_edit)
+        self.spy_btn = QPushButton(TEXT["spy"])
+        form.addWidget(self.spy_btn)
+        layout.addLayout(form)
+
+        self.table = QTableWidget(0, 5)
+        self.table.setHorizontalHeaderLabels([
+            TEXT["column_selector"],
+            TEXT["column_name"],
+            TEXT["column_auto"],
+            TEXT["column_type"],
+            TEXT["column_class"],
+        ])
+        layout.addWidget(self.table)
+
+        btns = QHBoxLayout()
+        self.remove_btn = QPushButton(TEXT["remove"])
+        self.close_btn = QPushButton(TEXT["close"])
+        btns.addWidget(self.remove_btn)
+        btns.addWidget(self.close_btn)
+        layout.addLayout(btns)
+
+        self.spy_btn.clicked.connect(self._on_spy)
+        self.remove_btn.clicked.connect(self._remove_selected)
+        self.close_btn.clicked.connect(self.accept)
+
+    def _on_spy(self) -> None:
+        selector = self.selector_edit.text().strip()
+        if not selector:
+            return
+        info = element_spy(selector)
+        row = self.table.rowCount()
+        self.table.insertRow(row)
+        self.table.setItem(row, 0, QTableWidgetItem(info.selector))
+        self.table.setItem(row, 1, QTableWidgetItem(info.name or ""))
+        self.table.setItem(row, 2, QTableWidgetItem(info.automation_id or ""))
+        self.table.setItem(row, 3, QTableWidgetItem(info.control_type or ""))
+        self.table.setItem(row, 4, QTableWidgetItem(info.class_name or ""))
+        self.selector_edit.clear()
+
+    def _remove_selected(self) -> None:
+        rows = sorted({idx.row() for idx in self.table.selectedIndexes()}, reverse=True)
+        for row in rows:
+            self.table.removeRow(row)

--- a/rpa_main_ui.py
+++ b/rpa_main_ui.py
@@ -53,6 +53,7 @@ from workflow.logging import set_step_log_callback
 from workflow.actions import list_actions
 from settings_dialog import SettingsDialog
 from selector_editor_dialog import SelectorEditorDialog
+from element_manager_dialog import ElementManagerDialog
 
 # Global queue receiving actions recorded by external modules
 recorded_actions_q: "queue.Queue[dict]" = queue.Queue()
@@ -86,6 +87,7 @@ TEXT = {
     "tooltip_settings": "設定を開きます",
     "tooltip_history": "実行履歴を表示します",
     "tooltip_approval": "このフローの承認を依頼します",
+    "tooltip_elements": "要素を取得・管理します",
     "log_header_time": "時刻",
     "log_header_step": "ステップ",
     "log_header_status": "状態",
@@ -653,6 +655,7 @@ class HeaderBar(QWidget):
         self.sett_btn = QPushButton("⚙ 設定"); self.sett_btn.setProperty("class","ghost")
         self.hist_btn = QPushButton("履歴"); self.hist_btn.setProperty("class","ghost")
         self.appr_btn = QPushButton("承認依頼"); self.appr_btn.setProperty("class","ghost")
+        self.elem_btn = QPushButton("要素"); self.elem_btn.setProperty("class","ghost")
         self.adv_chk = QCheckBox("詳細設定"); self.adv_chk.setProperty("class","ghost")
 
         # basic context help so first-time users understand the actions
@@ -662,9 +665,10 @@ class HeaderBar(QWidget):
         self.sett_btn.setToolTip(TEXT["tooltip_settings"])
         self.hist_btn.setToolTip(TEXT["tooltip_history"])
         self.appr_btn.setToolTip(TEXT["tooltip_approval"])
+        self.elem_btn.setToolTip(TEXT["tooltip_elements"])
         left = QHBoxLayout(); left.setSpacing(8)
         left.addWidget(self.run_btn); left.addWidget(self.stop_btn); left.addWidget(self.dry_btn); left.addWidget(self.sett_btn)
-        left.addWidget(self.hist_btn); left.addWidget(self.appr_btn); left.addWidget(self.adv_chk)
+        left.addWidget(self.hist_btn); left.addWidget(self.appr_btn); left.addWidget(self.elem_btn); left.addWidget(self.adv_chk)
         h.addLayout(left); h.addStretch(1)
         user = QLabel("🔍    👤"); user.setStyleSheet("color:#8AA0C6;")
         h.addWidget(user)
@@ -879,6 +883,7 @@ class MainWindow(QMainWindow):
         self.header.sett_btn.clicked.connect(self.on_setting)
         self.header.hist_btn.clicked.connect(self.show_history)
         self.header.appr_btn.clicked.connect(self.request_approval)
+        self.header.elem_btn.clicked.connect(self.open_element_manager)
         self.header.adv_chk.toggled.connect(self._on_adv_toggled)
         # Add steps with a single click from the action palette instead of requiring a double-click
         self.action_palette.list.itemClicked.connect(self.palette_clicked)
@@ -1149,6 +1154,10 @@ class MainWindow(QMainWindow):
             self.log_panel.add_row(
                 datetime.now().strftime("%H:%M:%S"), "Setting", "Canceled", False
             )
+
+    def open_element_manager(self):
+        dlg = ElementManagerDialog(self)
+        dlg.exec()
 
     def show_history(self):
         flow = Flow.from_dict(json.loads(self.current_flow_path.read_text()))

--- a/tests/test_element_manager_dialog.py
+++ b/tests/test_element_manager_dialog.py
@@ -1,0 +1,24 @@
+import pytest
+
+pytest.importorskip("PyQt6")
+from PyQt6.QtWidgets import QApplication
+
+from element_manager_dialog import ElementManagerDialog
+from workflow.gui_tools import ElementInfo
+
+
+def test_spy_adds_row(monkeypatch):
+    app = QApplication.instance() or QApplication([])
+
+    def fake_spy(selector: str) -> ElementInfo:
+        return ElementInfo(selector=selector, name="n", automation_id="a", control_type="c", class_name="cls")
+
+    monkeypatch.setattr("element_manager_dialog.element_spy", fake_spy)
+
+    dlg = ElementManagerDialog()
+    dlg.selector_edit.setText("#login")
+    dlg._on_spy()
+    assert dlg.table.rowCount() == 1
+    dlg.table.selectRow(0)
+    dlg._remove_selected()
+    assert dlg.table.rowCount() == 0

--- a/tests/test_hot_reload_watchdog.py
+++ b/tests/test_hot_reload_watchdog.py
@@ -2,6 +2,9 @@ import threading
 import time
 from pathlib import Path
 
+import pytest
+
+pytest.importorskip("PyQt6")
 from PyQt6.QtWidgets import QApplication
 
 import rpa_main_ui

--- a/tests/test_integration_profiles.py
+++ b/tests/test_integration_profiles.py
@@ -23,7 +23,8 @@ def test_environment_integration(monkeypatch, profile, dpi, lang):
 
     # Provide a fake OCR backend that echoes the requested language
     pytesseract = types.SimpleNamespace(
-        image_to_string=lambda img, lang=None: f"text-{lang}"
+        image_to_string=lambda img, lang=None: f"text-{lang}",
+        get_languages=lambda config="": ["eng", "jpn"],
     )
     sys.modules["pytesseract"] = pytesseract
 


### PR DESCRIPTION
## Summary
- Add ElementManagerDialog for capturing and managing element data
- Hook dialog into main UI via new header button
- Cover element manager and environment features with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68987891d85c8327ad8ed17a1cf379c9