### PR TITLE
feat: separate element types

### DIFF
--- a/tests/test_element_manager_dialog.py
+++ b/tests/test_element_manager_dialog.py
@@ -18,7 +18,8 @@ def test_spy_adds_row(monkeypatch):
     dlg = ElementManagerDialog()
     dlg.selector_edit.setText("#login")
     dlg._on_spy()
-    assert dlg.table.rowCount() == 1
-    dlg.table.selectRow(0)
+    assert dlg.desktop_table.rowCount() == 1
+    dlg.tabs.setCurrentWidget(dlg.desktop_table)
+    dlg.desktop_table.selectRow(0)
     dlg._remove_selected()
-    assert dlg.table.rowCount() == 0
+    assert dlg.desktop_table.rowCount() == 0


### PR DESCRIPTION
## Summary
- add tabs for desktop, web, and coordinate elements
- extend element manager to categorize captured elements
- adjust dialog tests for new UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898bedcfe248327ab4daea4f3f60b01